### PR TITLE
Added named and ordered parameter support

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/Keys.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/Keys.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import io.quarkiverse.jsonrpc.runtime.model.JsonRPCRequest;
+
+/**
+ * Helps with creating keys used to identify the method
+ *
+ * @author Phillip Kruger (phillip.kruger@gmail.com)
+ */
+public class Keys {
+
+    public static String createKey(JsonRPCRequest jsonRpcRequest) {
+        String fullMethod = jsonRpcRequest.getMethod();
+        if (!jsonRpcRequest.hasNamedParams()) {
+            return fullMethod;
+        }
+        // Parameters
+        String paramsString = formatKeys(jsonRpcRequest.getNamedParamKeys());
+        return fullMethod + paramsString;
+    }
+
+    /**
+     * Name is a combination of ClassName/scope and method name
+     *
+     * @return the key
+     */
+    public static String createKey(String scope, String method) {
+        return createKey(scope, method, null);
+    }
+
+    /**
+     * Name is a combination of ClassName/scope and method name and optionally ordered parameter names
+     *
+     * @return the key
+     */
+    public static String createKey(String scope, String method, Set<String> params) {
+        String paramsString = formatKeys(params);
+        return String.format(FULL_NAME_FORMAT, scope, method, paramsString);
+    }
+
+    /**
+     * Key used to lookup the name based on unnamed parameters
+     *
+     * @return the key
+     */
+    public static String createOrderedParameterKey(String scope, String method, int numOfParameters) {
+        return String.format(ORDERED_PARAM_FORMAT, scope, method, numOfParameters);
+    }
+
+    static String createOrderedParameterKey(JsonRPCRequest jsonRpcRequest) {
+        String fullMethod = jsonRpcRequest.getMethod();
+        if (!jsonRpcRequest.hasPositionedParams()) {
+            return fullMethod;
+        }
+        // Parameters
+        return fullMethod + "[" + jsonRpcRequest.getPositionedParams().length + "]";
+    }
+
+    private static String formatKeys(Set<String> params) {
+        String paramsString = "";
+        if (params != null && !params.isEmpty()) {
+            // Sort the params
+            List<String> paramList = new ArrayList<>(params);
+            Collections.sort(paramList);
+            paramsString = "(" + String.join("|", paramList) + ")";
+        }
+        return paramsString;
+    }
+
+    private static final String FULL_NAME_FORMAT = "%s#%s%s";
+    private static final String ORDERED_PARAM_FORMAT = "%s#%s[%d]";
+
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCMethodName.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCMethodName.java
@@ -5,12 +5,14 @@ import java.util.Objects;
 public final class JsonRPCMethodName {
 
     private String name;
+    private String orderedParameterKey = null;
 
     public JsonRPCMethodName() {
     }
 
-    public JsonRPCMethodName(String name) {
+    public JsonRPCMethodName(String name, String orderedParameterKey) {
         this.name = name;
+        this.orderedParameterKey = orderedParameterKey;
     }
 
     public String getName() {
@@ -19,6 +21,18 @@ public final class JsonRPCMethodName {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public boolean hasOrderedParameterKey() {
+        return orderedParameterKey != null;
+    }
+
+    public String getOrderedParameterKey() {
+        return orderedParameterKey;
+    }
+
+    public void setOrderedParameterKey(String orderedParameterKey) {
+        this.orderedParameterKey = orderedParameterKey;
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCRequest.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCRequest.java
@@ -7,15 +7,19 @@ import static io.quarkiverse.jsonrpc.runtime.model.JsonRPCKeys.PARAMS;
 import static io.quarkiverse.jsonrpc.runtime.model.JsonRPCKeys.VERSION;
 
 import java.util.Map;
+import java.util.Set;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class JsonRPCRequest {
 
     private final JsonObject jsonObject;
+    private final ParamOption paramOption;
 
     JsonRPCRequest(JsonObject jsonObject) {
         this.jsonObject = jsonObject;
+        this.paramOption = parametersProvidedAs();
     }
 
     public int getId() {
@@ -35,27 +39,80 @@ public class JsonRPCRequest {
     }
 
     public boolean hasParams() {
-        return this.getParams() != null;
+        return hasNamedParams() || hasPositionedParams();
     }
 
-    public Map<?, ?> getParams() {
-        JsonObject paramsObject = jsonObject.getJsonObject(PARAMS);
-        if (paramsObject != null && paramsObject.getMap() != null && !paramsObject.getMap().isEmpty()) {
-            return paramsObject.getMap();
+    public boolean hasNamedParams() {
+        return this.getNamedParams() != null;
+    }
+
+    public boolean hasPositionedParams() {
+        return this.getPositionedParams() != null;
+    }
+
+    public Map<String, Object> getNamedParams() {
+        if (paramOption.equals(ParamOption.OBJECT)) {
+            JsonObject paramsObject = jsonObject.getJsonObject(PARAMS);
+            if (paramsObject != null && paramsObject.getMap() != null && !paramsObject.getMap().isEmpty()) {
+                return paramsObject.getMap();
+            }
         }
         return null;
     }
 
-    public <T> T getParam(String key, Class<T> paramType) {
-        Map<?, ?> params = getParams();
+    public Object[] getPositionedParams() {
+        if (paramOption.equals(ParamOption.ARRAY)) {
+            JsonArray paramsObject = jsonObject.getJsonArray(PARAMS);
+            if (paramsObject != null && !paramsObject.isEmpty()) {
+                return paramsObject.stream().toArray(Object[]::new);
+            }
+        }
+        return null;
+    }
+
+    public <T> T getNamedParam(String key, Class<T> paramType) {
+        Map<?, ?> params = getNamedParams();
         if (params == null || !params.containsKey(key)) {
             return null;
         }
         return (T) params.get(key);
     }
 
+    public <T> T getPositionedParam(int pos, Class<T> paramType) {
+        Object[] params = getPositionedParams();
+        if (params == null || params.length == 0) {
+            return null;
+        }
+        return (T) params[pos - 1];
+    }
+
+    public Set<String> getNamedParamKeys() {
+        Map<String, Object> namedParams = getNamedParams();
+        if (namedParams != null && !namedParams.isEmpty()) {
+            return namedParams.keySet();
+        }
+        return null;
+    }
+
+    private ParamOption parametersProvidedAs() {
+
+        Object value = jsonObject.getValue(PARAMS);
+        if (value == null) {
+            return null;
+        } else if (value instanceof JsonObject) {
+            return ParamOption.OBJECT;
+        } else {
+            return ParamOption.ARRAY;
+        }
+    }
+
     @Override
     public String toString() {
         return jsonObject.encodePrettily();
+    }
+
+    enum ParamOption {
+        ARRAY,
+        OBJECT
     }
 }

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/HelloResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/HelloResource.java
@@ -8,4 +8,12 @@ public class HelloResource {
     public String hello() {
         return "Hello";
     }
+
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+
+    public String hello(String name, String surname) {
+        return "Hello " + name + " " + surname;
+    }
 }

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/ScopedHelloResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/ScopedHelloResource.java
@@ -8,4 +8,12 @@ public class ScopedHelloResource {
     public String hello() {
         return "Hello scoped";
     }
+
+    public String hello(String name) {
+        return "Hello scoped " + name;
+    }
+
+    public String hello(String name, String surname) {
+        return "Hello scoped " + name + " " + surname;
+    }
 }


### PR DESCRIPTION
This add support for named and ordered parameters:

Named: 
```
{
   "jsonrpc": "2.0",
   "id": 1,
   "method": "scoped#hello",
   "params": {"name": "Koos"}
}	
```

Ordered:
```
{
   "jsonrpc": "2.0",
   "id": 1,
   "method": "scoped#hello",
   "params": ["Phillip", "Kruger"]
}	
```