### PR TITLE
Improve CDI handling of JsonRPCRouter

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -1,9 +1,14 @@
 package io.quarkiverse.jsonrpc.runtime;
 
 import java.util.Map;
+import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
@@ -12,13 +17,26 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class JsonRPCRecorder {
 
-    public void createJsonRpcRouter(BeanContainer beanContainer,
+    public Function<SyntheticCreationalContext<JsonRPCRouter>, JsonRPCRouter> createJsonRpcRouter(
             Map<JsonRPCMethodName, JsonRPCMethod> methodsMap) {
-        JsonRPCRouter jsonRpcRouter = beanContainer.beanInstance(JsonRPCRouter.class);
-        jsonRpcRouter.populateJsonRPCMethods(methodsMap);
+        return new Function<>() {
+            @Override
+            public JsonRPCRouter apply(SyntheticCreationalContext<JsonRPCRouter> context) {
+                return new JsonRPCRouter(new JsonRPCCodec(context.getInjectedReference(ObjectMapper.class)), methodsMap);
+            }
+        };
     }
 
-    public Handler<RoutingContext> webSocketHandler() {
-        return new JsonRPCWebSocket();
+    public Function<SyntheticCreationalContext<JsonRPCWebSocket>, JsonRPCWebSocket> createJsonRpcWebSocket() {
+        return new Function<>() {
+            @Override
+            public JsonRPCWebSocket apply(SyntheticCreationalContext<JsonRPCWebSocket> context) {
+                return new JsonRPCWebSocket(context.getInjectedReference(JsonRPCRouter.class));
+            }
+        };
+    }
+
+    public Handler<RoutingContext> webSocketHandler(BeanContainer beanContainer) {
+        return new JsonRPCWebSocket(beanContainer.beanInstance(JsonRPCRouter.class));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCWebSocket.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCWebSocket.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.jsonrpc.runtime;
 
-import jakarta.enterprise.inject.spi.CDI;
-
 import org.jboss.logging.Logger;
 
 import io.vertx.core.AsyncResult;
@@ -14,6 +12,12 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class JsonRPCWebSocket implements Handler<RoutingContext> {
     private static final Logger LOG = Logger.getLogger(JsonRPCWebSocket.class.getName());
+
+    private final JsonRPCRouter jsonRpcRouter;
+
+    public JsonRPCWebSocket(JsonRPCRouter jsonRpcRouter) {
+        this.jsonRpcRouter = jsonRpcRouter;
+    }
 
     @Override
     public void handle(RoutingContext event) {
@@ -35,7 +39,6 @@ public class JsonRPCWebSocket implements Handler<RoutingContext> {
     }
 
     private void addSocket(ServerWebSocket session) {
-        JsonRPCRouter jsonRpcRouter = CDI.current().select(JsonRPCRouter.class).get();
         jsonRpcRouter.addSocket(session);
     }
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -7,15 +7,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.quarkus.arc.Arc;
 import io.vertx.core.http.ServerWebSocket;
 
 public class JsonRPCCodec {
     private static final Logger LOG = Logger.getLogger(JsonRPCCodec.class);
     private final ObjectMapper objectMapper;
 
-    public JsonRPCCodec() {
-        this.objectMapper = Arc.container().select(ObjectMapper.class).get();
+    public JsonRPCCodec(ObjectMapper originalObjectMapper) {
+        this.objectMapper = originalObjectMapper.copy(); // we should never change settings of the original ObjectMapper as they could have global impact
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 


### PR DESCRIPTION
Use a SyntheticBeanBuildItem in order to ensure
bean is created via it's constructor without
hidden references to Arc or CDI in the creation
process