### PR TITLE
docs: add README and Antora documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,69 @@
-# Quarkus Json Rpc
+# Quarkus JSON-RPC
 
 [![Version](https://img.shields.io/maven-central/v/io.quarkiverse.json-rpc/quarkus-json-rpc?logo=apache-maven&style=flat-square)](https://central.sonatype.com/artifact/io.quarkiverse.json-rpc/quarkus-json-rpc-parent)
 
-## Welcome to Quarkiverse!
+A Quarkus extension that provides [JSON-RPC 2.0](https://www.jsonrpc.org/specification) protocol support over WebSocket. Annotate your classes with `@JsonRPCApi` and their public methods become callable via JSON-RPC — no boilerplate, no manual routing.
 
-Congratulations and thank you for creating a new Quarkus extension project in Quarkiverse!
+## Get Started
 
-Feel free to replace this content with the proper description of your new project and necessary instructions how to use and contribute to it.
+### 1. Add the dependency
 
-You can find the basic info, Quarkiverse policies and conventions in [the Quarkiverse wiki](https://github.com/quarkiverse/quarkiverse/wiki).
+```xml
+<dependency>
+    <groupId>io.quarkiverse.json-rpc</groupId>
+    <artifactId>quarkus-json-rpc</artifactId>
+    <version>${quarkus-json-rpc.version}</version>
+</dependency>
+```
 
-In case you are creating a Quarkus extension project for the first time, please follow [Building My First Extension](https://quarkus.io/guides/building-my-first-extension) guide.
+### 2. Create your API
 
-Other useful articles related to Quarkus extension development can be found under the [Writing Extensions](https://quarkus.io/guides/#writing-extensions) guide category on the [Quarkus.io](https://quarkus.io) website.
+```java
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.mutiny.Uni;
 
-Thanks again, good luck and have fun!
+@JsonRPCApi
+public class GreetingService {
+
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+
+    public Uni<String> helloAsync(String name) {
+        return Uni.createFrom().item("Hello " + name);
+    }
+}
+```
+
+### 3. Call it over WebSocket
+
+Connect to `ws://localhost:8080/quarkus/json-rpc` and send:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "GreetingService#hello",
+  "params": { "name": "World" }
+}
+```
+
+## Features
+
+- **JSON-RPC 2.0** — full protocol compliance including error codes and notifications
+- **WebSocket transport** — bidirectional communication out of the box
+- **Reactive** — `Uni<T>` for async results, `Multi<T>` for streaming subscriptions
+- **Blocking & non-blocking** — control execution threads with `@Blocking` and `@NonBlocking`
+- **Server push** — broadcast notifications to all clients or target specific sessions
+- **Named & positional parameters** — both JSON object and array parameter styles
+- **POJO support** — automatic Jackson serialization for complex types
+- **Native image** — full GraalVM native compilation support
+- **Dev UI** — interactive method tester and endpoint browser
 
 ## Documentation
 
-The documentation for this extension should be maintained as part of this repository and it is stored in the `docs/` directory.
+The full documentation is available at https://docs.quarkiverse.io/quarkus-json-rpc/dev/index.html.
 
-The layout should follow the [Antora's Standard File and Directory Set](https://docs.antora.org/antora/2.3/standard-directories/).
+## Samples
 
-Once the docs are ready to be published, please open a PR including this repository in the [Quarkiverse Docs Antora playbook](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml#L7). See an example [here](https://github.com/quarkiverse/quarkiverse-docs/pull/1)
-
-Your documentation will then be published to the https://docs.quarkiverse.io/ website.
+Browse the [sample application](sample/) for working examples covering all supported return types, parameter styles, scoped APIs, and streaming.

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,1 +1,11 @@
-* xref:index.adoc[Getting started]
+* xref:index.adoc[Overview]
+
+.Guides
+** xref:guides-creating-api.adoc[Creating an API]
+** xref:guides-execution-modes.adoc[Execution Modes & Return Types]
+** xref:guides-parameters.adoc[Parameters]
+** xref:guides-streaming.adoc[Streaming with Multi]
+** xref:guides-broadcasting.adoc[Broadcasting]
+
+.Reference
+** xref:reference-configuration.adoc[Configuration]

--- a/docs/modules/ROOT/pages/guides-broadcasting.adoc
+++ b/docs/modules/ROOT/pages/guides-broadcasting.adoc
@@ -1,0 +1,97 @@
+= Broadcasting
+
+include::./includes/attributes.adoc[]
+
+The `JsonRPCBroadcaster` service lets you push JSON-RPC notifications from the server to connected WebSocket clients. Inject it into any CDI bean — it does not need to be a `@JsonRPCApi` class.
+
+== Broadcast to All Clients
+
+[source,java]
+----
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.quarkiverse.jsonrpc.api.JsonRPCBroadcaster;
+import jakarta.inject.Inject;
+
+@JsonRPCApi
+public class NotificationService {
+
+    @Inject
+    JsonRPCBroadcaster broadcaster;
+
+    public String publishUpdate(String message) {
+        broadcaster.broadcast("update", Map.of("message", message));
+        return "sent";
+    }
+}
+----
+
+All connected clients receive a JSON-RPC notification:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "method": "update",
+  "params": {
+    "result": {
+      "message": "Something happened"
+    }
+  }
+}
+----
+
+== Send to a Specific Session
+
+Target a single client by session ID:
+
+[source,java]
+----
+@JsonRPCApi
+public class NotificationService {
+
+    @Inject
+    JsonRPCBroadcaster broadcaster;
+
+    public boolean notifyUser(String sessionId, String message) {
+        return broadcaster.send(sessionId, "alert", Map.of("message", message));
+    }
+}
+----
+
+Returns `true` if the session was found and the message was sent, `false` otherwise.
+
+== List Connected Sessions
+
+You can query the set of currently connected session IDs:
+
+[source,java]
+----
+@JsonRPCApi
+public class SessionService {
+
+    @Inject
+    JsonRPCBroadcaster broadcaster;
+
+    public Set<String> activeSessions() {
+        return broadcaster.connectedSessions();
+    }
+}
+----
+
+== Use Outside @JsonRPCApi
+
+`JsonRPCBroadcaster` is a regular CDI bean. You can inject it anywhere — a REST endpoint, a scheduled job, an event observer:
+
+[source,java]
+----
+@ApplicationScoped
+public class EventProcessor {
+
+    @Inject
+    JsonRPCBroadcaster broadcaster;
+
+    public void onOrderPlaced(@Observes OrderPlacedEvent event) {
+        broadcaster.broadcast("orderPlaced", event);
+    }
+}
+----

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -1,0 +1,141 @@
+= Creating an API
+
+include::./includes/attributes.adoc[]
+
+== The @JsonRPCApi Annotation
+
+Annotate any class with `@JsonRPCApi` to expose its public methods as JSON-RPC endpoints:
+
+[source,java]
+----
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class GreetingService {
+
+    public String hello() {
+        return "Hello";
+    }
+
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+}
+----
+
+The extension discovers annotated classes at build time. Each public method with a non-void return type becomes a JSON-RPC method.
+
+== Method Names
+
+Methods are addressed using the format `ClassName#methodName`. For the example above, clients call:
+
+- `GreetingService#hello` (no params) — calls `hello()`
+- `GreetingService#hello` (with a `name` param) — calls `hello(String name)`
+
+The framework disambiguates overloaded methods by the number and names of the parameters provided.
+
+== Custom Scope
+
+By default, the class simple name is used as the scope prefix. You can provide a custom scope:
+
+[source,java]
+----
+@JsonRPCApi("greet")
+public class GreetingService {
+
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+}
+----
+
+Now the method is called as `greet#hello` instead of `GreetingService#hello`. This is useful for versioning or logical grouping.
+
+== Method Discovery Rules
+
+The following rules apply when the extension scans your class:
+
+- Only **public** methods are exposed.
+- Methods **must** have a non-void return type.
+- Constructors and static methods are ignored.
+- Private and package-private methods are ignored.
+
+== CDI Integration
+
+All `@JsonRPCApi` classes are automatically registered as `@ApplicationScoped` CDI beans. You can inject any CDI bean:
+
+[source,java]
+----
+@JsonRPCApi
+public class OrderService {
+
+    @Inject
+    OrderRepository repository;
+
+    public Order getOrder(String id) {
+        return repository.findById(id);
+    }
+}
+----
+
+== WebSocket Endpoint
+
+All JSON-RPC methods are served through a single WebSocket endpoint. By default, this is:
+
+----
+ws://localhost:8080/quarkus/json-rpc
+----
+
+See xref:reference-configuration.adoc[Configuration Reference] to change the path.
+
+== JSON-RPC 2.0 Protocol
+
+Requests follow the https://www.jsonrpc.org/specification[JSON-RPC 2.0 specification]:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "GreetingService#hello",
+  "params": { "name": "World" }
+}
+----
+
+Successful responses:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "Hello World"
+}
+----
+
+Error responses:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Method not found"
+  }
+}
+----
+
+Standard JSON-RPC 2.0 error codes are used:
+
+[cols="1,3"]
+|===
+| Code | Meaning
+
+| -32700 | Parse error
+| -32600 | Invalid request
+| -32601 | Method not found
+| -32602 | Invalid params
+| -32603 | Internal error
+|===

--- a/docs/modules/ROOT/pages/guides-execution-modes.adoc
+++ b/docs/modules/ROOT/pages/guides-execution-modes.adoc
@@ -1,0 +1,133 @@
+= Execution Modes & Return Types
+
+include::./includes/attributes.adoc[]
+
+The extension supports several return types, each with different execution semantics. You can further control threading with the `@Blocking` and `@NonBlocking` annotations.
+
+== Synchronous Methods
+
+Plain return types run on a worker thread by default (blocking):
+
+[source,java]
+----
+@JsonRPCApi
+public class MyService {
+
+    // Runs on executor-thread (blocking, default)
+    public String compute(String input) {
+        return expensiveOperation(input);
+    }
+
+    // Runs on vert.x-eventloop-thread (non-blocking)
+    @NonBlocking
+    public String computeFast(String input) {
+        return cheapOperation(input);
+    }
+}
+----
+
+[cols="2,3"]
+|===
+| Return type | Default execution
+
+| Plain type (String, int, POJO, ...)
+| **Blocking** — worker thread via `vertx.executeBlocking()`
+
+| Plain type + `@NonBlocking`
+| **Non-blocking** — Vert.x event loop
+|===
+
+== Uni (Async Single Result)
+
+`Uni<T>` from https://smallrye.io/smallrye-mutiny/[Mutiny] returns a single async result:
+
+[source,java]
+----
+@JsonRPCApi
+public class MyService {
+
+    // Non-blocking by default
+    public Uni<String> fetchData(String id) {
+        return dataClient.get(id);
+    }
+
+    // Force blocking execution
+    @Blocking
+    public Uni<String> fetchDataBlocking(String id) {
+        return Uni.createFrom().item(blockingLookup(id));
+    }
+}
+----
+
+[cols="2,3"]
+|===
+| Return type | Default execution
+
+| `Uni<T>`
+| **Non-blocking** — event loop
+
+| `Uni<T>` + `@Blocking`
+| **Blocking** — wrapped in `vertx.executeBlocking()`
+|===
+
+== CompletionStage / CompletableFuture
+
+Standard Java async types are also supported and behave like `Uni<T>`:
+
+[source,java]
+----
+@JsonRPCApi
+public class MyService {
+
+    public CompletionStage<String> fetchAsync(String id) {
+        return CompletableFuture.supplyAsync(() -> lookup(id));
+    }
+}
+----
+
+== Multi (Streaming)
+
+`Multi<T>` enables server-sent streaming via JSON-RPC subscriptions. See xref:guides-streaming.adoc[Streaming with Multi] for the full protocol details.
+
+[source,java]
+----
+@JsonRPCApi
+public class MyService {
+
+    public Multi<String> ticker() {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .onItem().transform(n -> "tick " + n);
+    }
+}
+----
+
+`Flow.Publisher<T>` is also supported and treated identically to `Multi<T>`.
+
+== Summary
+
+[cols="3,2,2"]
+|===
+| Return type | Default | Override
+
+| Plain type
+| Blocking
+| `@NonBlocking`
+
+| `Uni<T>`
+| Non-blocking
+| `@Blocking`
+
+| `CompletionStage<T>`
+| Non-blocking
+| `@Blocking`
+
+| `Multi<T>`
+| Non-blocking
+| —
+
+| `Flow.Publisher<T>`
+| Non-blocking
+| —
+|===
+
+NOTE: A method cannot be annotated with both `@Blocking` and `@NonBlocking`. The build will fail if both are present.

--- a/docs/modules/ROOT/pages/guides-parameters.adoc
+++ b/docs/modules/ROOT/pages/guides-parameters.adoc
@@ -1,0 +1,136 @@
+= Parameters
+
+include::./includes/attributes.adoc[]
+
+JSON-RPC 2.0 supports two styles of parameter passing: named parameters (JSON object) and positional parameters (JSON array). This extension supports both.
+
+== Named Parameters
+
+Pass parameters as a JSON object where keys match the Java method parameter names:
+
+[source,java]
+----
+@JsonRPCApi
+public class UserService {
+
+    public String greet(String name, String surname) {
+        return "Hello " + name + " " + surname;
+    }
+}
+----
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "UserService#greet",
+  "params": {
+    "name": "John",
+    "surname": "Doe"
+  }
+}
+----
+
+NOTE: Parameter names must match exactly. The project uses the `-parameters` compiler flag so that Java method parameter names are available at runtime.
+
+== Positional Parameters
+
+Pass parameters as a JSON array, matched by position:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "UserService#greet",
+  "params": ["John", "Doe"]
+}
+----
+
+The first array element maps to the first method parameter, the second to the second, and so on.
+
+== Supported Parameter Types
+
+The extension uses Jackson for deserialization, so any type that Jackson can handle is supported:
+
+- **Primitives and wrappers**: `int`, `long`, `boolean`, `double`, `String`, etc.
+- **Java time types**: `LocalDateTime`, `LocalDate`, `Instant`, etc.
+- **UUID**: `java.util.UUID`
+- **Collections**: `List<T>`, `Set<T>`, `Map<K,V>`
+- **Arrays**: `T[]`
+- **POJOs**: any class with a default constructor and getters/setters
+
+== Complex Object Parameters
+
+You can pass complex objects as parameters:
+
+[source,java]
+----
+public class Person {
+    private String name;
+    private String surname;
+    // getters and setters
+}
+
+@JsonRPCApi
+public class PersonService {
+
+    public Person echo(Person person) {
+        return person;
+    }
+}
+----
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "PersonService#echo",
+  "params": {
+    "person": {
+      "name": "John",
+      "surname": "Doe"
+    }
+  }
+}
+----
+
+== No Parameters
+
+Methods without parameters can be called with no `params` field or with an empty object/array:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "MyService#status"
+}
+----
+
+== Method Overloading
+
+The extension supports method overloading. Methods with the same name but different parameter counts are disambiguated based on the number of parameters provided:
+
+[source,java]
+----
+@JsonRPCApi
+public class GreetingService {
+
+    public String hello() {
+        return "Hello";
+    }
+
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+
+    public String hello(String name, String surname) {
+        return "Hello " + name + " " + surname;
+    }
+}
+----
+
+All three methods are called as `GreetingService#hello` — the correct overload is selected by the number of parameters in the request.

--- a/docs/modules/ROOT/pages/guides-streaming.adoc
+++ b/docs/modules/ROOT/pages/guides-streaming.adoc
@@ -1,0 +1,147 @@
+= Streaming with Multi
+
+include::./includes/attributes.adoc[]
+
+Methods that return `Multi<T>` (or `Flow.Publisher<T>`) enable streaming subscriptions. Instead of a single response, the client receives a stream of items as JSON-RPC notifications.
+
+== Creating a Stream
+
+[source,java]
+----
+@JsonRPCApi
+public class TickerService {
+
+    public Multi<String> ticker() {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .onItem().transform(n -> "tick " + n);
+    }
+
+    public Multi<StockPrice> prices(String symbol) {
+        return priceService.streamPrices(symbol);
+    }
+}
+----
+
+== Subscription Protocol
+
+When a client calls a `Multi` method, the following exchange happens:
+
+=== 1. Subscribe
+
+The client sends a normal JSON-RPC request:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "TickerService#ticker"
+}
+----
+
+=== 2. Acknowledgement
+
+The server responds with a subscription ID:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "sub-abc-123"
+}
+----
+
+=== 3. Items
+
+Each item emitted by the `Multi` is sent as a JSON-RPC notification:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "method": "subscription",
+  "params": {
+    "subscription": "sub-abc-123",
+    "result": "tick 0"
+  }
+}
+----
+
+=== 4. Completion
+
+When the stream completes, the server sends a completion notification:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "method": "subscription",
+  "params": {
+    "subscription": "sub-abc-123",
+    "complete": true
+  }
+}
+----
+
+=== 5. Error
+
+If the stream fails, an error notification is sent instead:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "method": "subscription",
+  "params": {
+    "subscription": "sub-abc-123",
+    "error": {
+      "code": -32603,
+      "message": "Method [...] failed: ..."
+    }
+  }
+}
+----
+
+== Unsubscribing
+
+A client can cancel a subscription by sending an `unsubscribe` request with the subscription ID:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "unsubscribe",
+  "params": ["sub-abc-123"]
+}
+----
+
+The server responds with `true` if the subscription was found and cancelled, or `false` if the subscription ID was unknown:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": true
+}
+----
+
+== Streaming POJOs
+
+`Multi` works with any serializable type, not just strings:
+
+[source,java]
+----
+@JsonRPCApi
+public class SensorService {
+
+    public Multi<SensorReading> readings(String sensorId) {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(5))
+                .onItem().transform(n -> readSensor(sensorId));
+    }
+}
+----
+
+Each item is serialized to JSON automatically via Jackson.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,14 +1,51 @@
-= Quarkus Json Rpc
+= Quarkus JSON-RPC
+:description: A Quarkus extension providing JSON-RPC 2.0 protocol support over WebSocket.
 
 include::./includes/attributes.adoc[]
 
-TIP: Describe what the extension does here.
+*Expose your Java methods as JSON-RPC 2.0 endpoints over WebSocket — with a single annotation.*
+
+Quarkus JSON-RPC discovers classes annotated with `@JsonRPCApi` at build time and makes their public methods callable via the https://www.jsonrpc.org/specification[JSON-RPC 2.0] protocol over a WebSocket connection. No manual routing, no protocol plumbing.
+
+== In a Glance
+
+[source,java]
+----
+@JsonRPCApi
+public class GreetingService {
+
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+}
+----
+
+Connect to `ws://localhost:8080/quarkus/json-rpc` and send:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "GreetingService#hello",
+  "params": { "name": "World" }
+}
+----
+
+Response:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "Hello World"
+}
+----
 
 == Installation
 
-If you want to use this extension, you need to add the `io.quarkiverse.json-rpc:quarkus-json-rpc` extension first to your build file.
-
-For instance, with Maven, add the following dependency to your POM file:
+Add the extension to your project:
 
 [source,xml,subs=attributes+]
 ----
@@ -19,9 +56,47 @@ For instance, with Maven, add the following dependency to your POM file:
 </dependency>
 ----
 
-[[extension-configuration-reference]]
-== Extension Configuration Reference
+== Key Features
 
-TIP: Remove this section if you don't have Quarkus configuration properties in your extension.
+Build-time discovery::
+All `@JsonRPCApi` classes are found at build time via Jandex — no runtime classpath scanning, full ahead-of-time compilation and GraalVM native image support.
 
-include::includes/quarkus-json-rpc.adoc[leveloffset=+1, opts=optional]
+Reactive and blocking::
+Return plain types for blocking execution, `Uni<T>` for async, or `Multi<T>` for streaming subscriptions. Fine-tune with `@Blocking` and `@NonBlocking`.
+
+Server push::
+Inject `JsonRPCBroadcaster` to send notifications to all connected clients or target a specific session.
+
+Flexible parameters::
+Call methods with named parameters (JSON object) or positional parameters (JSON array).
+
+POJO support::
+Complex types are serialized and deserialized automatically via Jackson, including nested objects, collections, and Java time types.
+
+Dev UI::
+An interactive method browser and tester is available in the Quarkus Dev UI during development.
+
+== What's Next?
+
+[cols="1,2"]
+|===
+| Page | Description
+
+| xref:guides-creating-api.adoc[Creating an API]
+| Annotate your first class and understand method discovery rules.
+
+| xref:guides-execution-modes.adoc[Execution Modes & Return Types]
+| Blocking, non-blocking, `Uni`, `Multi`, `CompletionStage` — how the extension dispatches your methods.
+
+| xref:guides-parameters.adoc[Parameters]
+| Named vs. positional parameters and supported types.
+
+| xref:guides-streaming.adoc[Streaming with Multi]
+| Subscribe to server-sent streams and manage subscriptions.
+
+| xref:guides-broadcasting.adoc[Broadcasting]
+| Push notifications to clients from any CDI bean.
+
+| xref:reference-configuration.adoc[Configuration Reference]
+| All available configuration properties.
+|===

--- a/docs/modules/ROOT/pages/reference-configuration.adoc
+++ b/docs/modules/ROOT/pages/reference-configuration.adoc
@@ -1,0 +1,7 @@
+= Configuration Reference
+
+include::./includes/attributes.adoc[]
+
+All configuration properties are fixed at build time.
+
+include::includes/quarkus-json-rpc.adoc[leveloffset=+1, opts=optional]


### PR DESCRIPTION
Replace the boilerplate README with a proper project description, a 3-step quick-start guide (add dependency, write code, call it), and feature highlights. Modeled after the quarkus-mcp-server README style.

Write full Antora documentation organized into Guides and Reference sections:

- **index.adoc** — landing page with code sample, installation, feature overview, and navigation
- **Creating an API** — `@JsonRPCApi`, method discovery, custom scopes, CDI, protocol format
- **Execution Modes & Return Types** — blocking, non-blocking, `Uni`, `CompletionStage`, `Multi`
- **Parameters** — named vs positional, supported types, complex objects, overloading
- **Streaming with Multi** — full subscription protocol (subscribe, ack, items, complete, error, unsubscribe)
- **Broadcasting** — `JsonRPCBroadcaster` for server push to all or targeted sessions
- **Configuration Reference** — includes the auto-generated config properties table