### PR TITLE
feat: generate JavaScript client proxy for JSON-RPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Connect to `ws://localhost:8080/quarkus/json-rpc` and send:
 - **Server push** — broadcast notifications to all clients or target specific sessions
 - **Named & positional parameters** — both JSON object and array parameter styles
 - **POJO support** — automatic Jackson serialization for complex types
+- **JavaScript client** — optional generated typed proxy for calling endpoints from the browser
 - **Native image** — full GraalVM native compilation support
 - **Dev UI** — interactive method tester and endpoint browser
 

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -1,6 +1,10 @@
 package io.quarkiverse.jsonrpc.deployment;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -9,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -46,6 +51,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
@@ -53,15 +59,23 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 
 public class JsonRPCProcessor {
+    private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(JsonRPCProcessor.class);
     private static final DotName JSON_RPC_API = DotName.createSimple("io.quarkiverse.jsonrpc.api.JsonRPCApi");
+    private static final Pattern JS_IDENTIFIER = Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$]*$");
+    private static final Set<String> JS_RESERVED_WORDS = Set.of(
+            "break", "case", "catch", "class", "const", "continue", "debugger", "default",
+            "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for",
+            "function", "if", "import", "in", "instanceof", "new", "null", "return", "super",
+            "switch", "this", "throw", "true", "try", "typeof", "var", "void", "while", "with",
+            "yield", "let", "static", "implements", "interface", "package", "private", "protected",
+            "public", "await");
     private static final String FEATURE = "json-rpc";
     private static final String CONSTRUCTOR = "<init>";
-
-    private final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -236,6 +250,146 @@ public class JsonRPCProcessor {
         }
     }
 
+    // JavaScript client proxy
+
+    @BuildStep
+    void generateJsClient(
+            JsonRPCConfig jsonRPCConfig,
+            JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
+            BuildProducer<GeneratedStaticResourceBuildItem> staticResourceProducer,
+            BuildProducer<GeneratedResourceBuildItem> generatedResourceProducer) {
+
+        if (!jsonRPCConfig.client().enabled()) {
+            return;
+        }
+
+        // 1. Copy the static client library
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try (InputStream is = tccl.getResourceAsStream("jsonrpc/jsonrpc-client.js")) {
+            if (is == null) {
+                throw new IllegalStateException("jsonrpc/jsonrpc-client.js not found on classpath");
+            }
+            staticResourceProducer.produce(
+                    new GeneratedStaticResourceBuildItem(
+                            "/_static/quarkus-json-rpc/jsonrpc-client.js",
+                            is.readAllBytes()));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        // 2. Generate the typed proxy module
+        Map<JsonRPCMethodName, JsonRPCMethod> methodsMap = jsonRPCMethodsBuildItem.getMethodsMap();
+        String proxyJs = generateTypedProxy(methodsMap, jsonRPCConfig.webSocket().path());
+        staticResourceProducer.produce(
+                new GeneratedStaticResourceBuildItem(
+                        "/_static/quarkus-json-rpc-api/jsonrpc-api.js",
+                        proxyJs.getBytes(StandardCharsets.UTF_8)));
+
+        // 3. Generate importmap.json for web-dependency-locator
+        String importmap = generateImportMap();
+        generatedResourceProducer.produce(
+                new GeneratedResourceBuildItem(
+                        "META-INF/importmap.json",
+                        importmap.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private String generateTypedProxy(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, String wsPath) {
+        StringBuilder js = new StringBuilder();
+        js.append("import { JsonRPCClient } from '/_static/quarkus-json-rpc/jsonrpc-client.js';\n\n");
+        js.append("export const client = new JsonRPCClient({ path: '").append(escapeJsString(wsPath)).append("' });\n\n");
+
+        // Group methods by scope and method name (sorted for deterministic output).
+        // Multiple overloads of the same method name share one JS proxy entry — the server
+        // resolves the correct overload based on parameters. We validate that all overloads
+        // agree on streaming vs non-streaming return type.
+        Map<String, Map<String, MethodEntry>> byScope = new java.util.TreeMap<>();
+        for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> entry : methodsMap.entrySet()) {
+            String key = entry.getKey().getName();
+            int hashIdx = key.indexOf('#');
+            String scope = key.substring(0, hashIdx);
+            validateJsIdentifier(scope, "@JsonRPCApi scope");
+            String methodName = entry.getValue().getMethodName();
+            validateJsIdentifier(methodName, "Method name '" + scope + "#" + methodName + "'");
+            Map<String, MethodEntry> scopeMethods = byScope.computeIfAbsent(scope, k -> new java.util.TreeMap<>());
+            MethodEntry existing = scopeMethods.get(methodName);
+            if (existing != null) {
+                // Overloaded method — verify return types agree on streaming vs non-streaming
+                boolean existingStreaming = isStreamingReturnType(existing.method);
+                boolean newStreaming = isStreamingReturnType(entry.getValue());
+                if (existingStreaming != newStreaming) {
+                    throw new IllegalArgumentException(
+                            "Overloaded method '" + scope + "#" + methodName + "' has conflicting return types: "
+                                    + "some overloads return a streaming type (Multi/Flow.Publisher) while others do not. "
+                                    + "The JavaScript client proxy cannot represent both call() and subscribe() "
+                                    + "under the same method name. Rename one of the overloads or make all overloads "
+                                    + "return the same category (all streaming or all non-streaming).");
+                }
+            } else {
+                scopeMethods.put(methodName, new MethodEntry(scope, methodName, entry.getValue()));
+            }
+        }
+
+        for (Map.Entry<String, Map<String, MethodEntry>> scopeEntry : byScope.entrySet()) {
+            String scope = scopeEntry.getKey();
+            Map<String, MethodEntry> methods = scopeEntry.getValue();
+
+            js.append("export const ").append(scope).append(" = {\n");
+            int i = 0;
+            for (MethodEntry me : methods.values()) {
+                boolean streaming = isStreamingReturnType(me.method);
+                String clientMethod = streaming ? "subscribe" : "call";
+                String methodKey = me.scope + "#" + me.methodName;
+                js.append("    ").append(me.methodName)
+                        .append(": (params) => client.").append(clientMethod)
+                        .append("('").append(methodKey).append("', params)");
+                if (i < methods.size() - 1) {
+                    js.append(",");
+                }
+                js.append("\n");
+                i++;
+            }
+            js.append("};\n\n");
+        }
+
+        return js.toString();
+    }
+
+    private String generateImportMap() {
+        return "{\n"
+                + "  \"imports\" : {\n"
+                + "    \"@quarkiverse/json-rpc\" : \"/_static/quarkus-json-rpc/jsonrpc-client.js\",\n"
+                + "    \"@quarkiverse/json-rpc/\" : \"/_static/quarkus-json-rpc/\",\n"
+                + "    \"@quarkiverse/json-rpc-api\" : \"/_static/quarkus-json-rpc-api/jsonrpc-api.js\"\n"
+                + "  }\n"
+                + "}\n";
+    }
+
+    private static final Set<String> STREAMING_TYPES = Set.of(
+            "io.smallrye.mutiny.Multi",
+            "java.util.concurrent.Flow$Publisher");
+
+    private boolean isStreamingReturnType(JsonRPCMethod method) {
+        int paramCount = method.hasParams() ? method.getParams().size() : 0;
+        return isReturnTypeAssignableTo(method.getClazz(), method.getMethodName(), paramCount, STREAMING_TYPES);
+    }
+
+    private record MethodEntry(String scope, String methodName, JsonRPCMethod method) {
+    }
+
+    private static String escapeJsString(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
+    }
+
+    private static void validateJsIdentifier(String name, String label) {
+        if (!JS_IDENTIFIER.matcher(name).matches() || JS_RESERVED_WORDS.contains(name)) {
+            throw new IllegalArgumentException(
+                    label + " '" + name + "' is not a valid JavaScript identifier. "
+                            + "Use a name that starts with a letter, underscore, or dollar sign, "
+                            + "contains only letters, digits, underscores, or dollar signs, "
+                            + "and is not a JavaScript reserved word.");
+        }
+    }
+
     // Dev UI
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)
@@ -319,33 +473,48 @@ public class JsonRPCProcessor {
         return actions;
     }
 
-    private static final Set<String> REACTIVE_TYPES = Set.of(
+    private static final Set<String> NON_STREAMING_REACTIVE_TYPES = Set.of(
             "io.smallrye.mutiny.Uni",
-            "io.smallrye.mutiny.Multi",
-            "java.util.concurrent.CompletionStage",
-            "java.util.concurrent.Flow$Publisher");
+            "java.util.concurrent.CompletionStage");
+
+    private static final Set<String> REACTIVE_TYPES;
+    static {
+        Set<String> all = new HashSet<>(NON_STREAMING_REACTIVE_TYPES);
+        all.addAll(STREAMING_TYPES);
+        REACTIVE_TYPES = Set.copyOf(all);
+    }
 
     private boolean isReactiveReturnType(Class<?> clazz, String methodName) {
+        return isReturnTypeAssignableTo(clazz, methodName, -1, REACTIVE_TYPES);
+    }
+
+    /**
+     * Check whether a method's return type is assignable to any of the given type names.
+     *
+     * @param paramCount number of parameters to match the correct overload, or -1 to match any
+     */
+    private boolean isReturnTypeAssignableTo(Class<?> clazz, String methodName, int paramCount, Set<String> typeNames) {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         try {
-            java.lang.reflect.Method m = null;
-            for (java.lang.reflect.Method candidate : clazz.getMethods()) {
-                if (candidate.getName().equals(methodName)) {
-                    m = candidate;
-                    break;
-                }
-            }
-            if (m != null) {
-                Class<?> returnType = m.getReturnType();
-                for (String reactiveType : REACTIVE_TYPES) {
-                    try {
-                        if (tccl.loadClass(reactiveType).isAssignableFrom(returnType)) {
-                            return true;
+            for (java.lang.reflect.Method m : clazz.getMethods()) {
+                if (m.getName().equals(methodName)
+                        && (paramCount < 0 || m.getParameterCount() == paramCount)) {
+                    Class<?> returnType = m.getReturnType();
+                    for (String typeName : typeNames) {
+                        try {
+                            if (tccl.loadClass(typeName).isAssignableFrom(returnType)) {
+                                return true;
+                            }
+                        } catch (ClassNotFoundException ignored) {
                         }
-                    } catch (ClassNotFoundException ignored) {
+                    }
+                    if (paramCount >= 0) {
+                        break;
                     }
                 }
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            LOG.debugf(e, "Failed to inspect return type of %s.%s", clazz.getName(), methodName);
         }
         return false;
     }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCClientConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCClientConfig.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.jsonrpc.deployment.config;
+
+import io.smallrye.config.WithDefault;
+
+public interface JsonRPCClientConfig {
+
+    /**
+     * Generate a JavaScript client proxy for all discovered JSON-RPC endpoints.
+     * When enabled, a static client library and a typed proxy module are generated
+     * as web resources, along with an import map following the mvnpm convention.
+     */
+    @WithDefault("false")
+    boolean enabled();
+}

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
@@ -17,4 +17,9 @@ public interface JsonRPCConfig {
      */
     @WithName("web-socket")
     JsonRPCWebSocketConfig webSocket();
+
+    /**
+     * Configuration properties for the JavaScript client proxy generation
+     */
+    JsonRPCClientConfig client();
 }

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -1,0 +1,353 @@
+/**
+ * Quarkus JSON-RPC 2.0 WebSocket Client
+ *
+ * Provides a Promise-based API for calling JSON-RPC methods and subscribing
+ * to streaming responses over WebSocket.
+ */
+
+export class JsonRPCClient {
+    _ws = null;
+    _url = null;
+    _path;
+    _nextId = 0;
+    _pending = new Map();
+    _subscriptions = new Map();
+    _listeners = new Map();
+    _autoReconnect;
+    _reconnectDelay;
+    _maxReconnectDelay;
+    _reconnectTimer = null;
+    _manuallyDisconnected = false;
+    _connected = false;
+
+    onOpen = null;
+    onClose = null;
+    onError = null;
+
+    constructor(options = {}) {
+        this._path = options.path || '/quarkus/json-rpc';
+        this._url = options.url || null;
+        this._autoReconnect = options.autoReconnect !== false;
+        this._reconnectDelay = 1000;
+        this._maxReconnectDelay = options.maxReconnectDelay || 30000;
+
+        if (options.onOpen) this.onOpen = options.onOpen;
+        if (options.onClose) this.onClose = options.onClose;
+        if (options.onError) this.onError = options.onError;
+
+        if (options.autoConnect !== false) {
+            this.connect();
+        }
+    }
+
+    get url() {
+        if (this._url) return this._url;
+        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        return `${protocol}//${location.host}${this._path}`;
+    }
+
+    set url(value) {
+        const changed = this._url !== value;
+        this._url = value;
+        if (changed && this._ws) {
+            this.disconnect();
+            this.connect();
+        }
+    }
+
+    get path() {
+        return this._path;
+    }
+
+    set path(value) {
+        const changed = this._path !== value;
+        this._path = value;
+        if (changed && this._ws && !this._url) {
+            this.disconnect();
+            this.connect();
+        }
+    }
+
+    get connected() {
+        return this._connected;
+    }
+
+    connect() {
+        this._manuallyDisconnected = false;
+        if (this._ws) return;
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+
+        const ws = new WebSocket(this.url);
+        this._ws = ws;
+
+        ws.onopen = () => {
+            this._connected = true;
+            this._reconnectDelay = 1000;
+            if (this.onOpen) this.onOpen();
+        };
+
+        ws.onclose = (event) => {
+            this._connected = false;
+            this._ws = null;
+
+            for (const [, pending] of this._pending) {
+                pending.reject(new Error('WebSocket closed'));
+            }
+            this._pending.clear();
+
+            for (const [, sub] of this._subscriptions) {
+                sub._push('error', new Error('WebSocket closed'));
+            }
+            this._subscriptions.clear();
+
+            if (this.onClose) this.onClose(event);
+
+            if (this._autoReconnect && !this._manuallyDisconnected) {
+                const jitter = Math.random() * 1000;
+                this._reconnectTimer = setTimeout(() => {
+                    this._reconnectTimer = null;
+                    this.connect();
+                }, this._reconnectDelay + jitter);
+                this._reconnectDelay = Math.min(
+                    this._reconnectDelay * 2,
+                    this._maxReconnectDelay
+                );
+            }
+        };
+
+        ws.onerror = (error) => {
+            if (this.onError) this.onError(error);
+        };
+
+        ws.onmessage = (event) => {
+            try {
+                this._handleMessage(JSON.parse(event.data));
+            } catch (e) {
+                if (this.onError) this.onError(e);
+            }
+        };
+    }
+
+    disconnect() {
+        this._manuallyDisconnected = true;
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+        if (this._ws) {
+            this._ws.close();
+            this._ws = null;
+        }
+    }
+
+    /**
+     * Call a JSON-RPC method and return a Promise for the result.
+     *
+     * @param {string} method - Method key, e.g. "HelloResource#hello"
+     * @param {Object|Array} [params] - Named params object or positional params array
+     * @returns {Promise<*>} Resolves with the result value, rejects with error
+     */
+    call(method, params) {
+        return new Promise((resolve, reject) => {
+            const id = ++this._nextId;
+            this._pending.set(id, { resolve, reject });
+            const msg = { jsonrpc: '2.0', id, method };
+            if (params != null) msg.params = params;
+            this._send(msg);
+        });
+    }
+
+    /**
+     * Subscribe to a streaming JSON-RPC method (Multi / Flow.Publisher).
+     * Returns a Subscription object for receiving items.
+     *
+     * @param {string} method - Method key, e.g. "PojoResource#pojoMulti"
+     * @param {Object|Array} [params] - Named params object or positional params array
+     * @returns {Subscription}
+     */
+    subscribe(method, params) {
+        const sub = new Subscription(this);
+        const id = ++this._nextId;
+        this._pending.set(id, {
+            resolve: (result) => {
+                sub._id = result;
+                this._subscriptions.set(result, sub);
+            },
+            reject: (error) => {
+                sub._push('error', error);
+            }
+        });
+        const msg = { jsonrpc: '2.0', id, method };
+        if (params != null) msg.params = params;
+        this._send(msg);
+        return sub;
+    }
+
+    /**
+     * Listen for server push notifications (from JsonRPCBroadcaster).
+     *
+     * @param {string} method - Notification method name
+     * @param {Function} callback - Called with the notification data
+     * @returns {Function} Unsubscribe function
+     */
+    on(method, callback) {
+        if (!this._listeners.has(method)) {
+            this._listeners.set(method, []);
+        }
+        this._listeners.get(method).push(callback);
+        return () => {
+            const cbs = this._listeners.get(method);
+            if (cbs) {
+                const idx = cbs.indexOf(callback);
+                if (idx >= 0) cbs.splice(idx, 1);
+            }
+        };
+    }
+
+    /**
+     * Cancel a streaming subscription by its ID.
+     *
+     * @param {string} subscriptionId - UUID returned by the subscription ACK
+     * @returns {Promise<boolean>}
+     */
+    unsubscribe(subscriptionId) {
+        return this.call('unsubscribe', { subscription: subscriptionId }).then(result => {
+            this._subscriptions.delete(subscriptionId);
+            return result;
+        });
+    }
+
+    _send(message) {
+        if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+            this._ws.send(JSON.stringify(message));
+        } else if (message.id !== undefined) {
+            const pending = this._pending.get(message.id);
+            if (pending) {
+                this._pending.delete(message.id);
+                pending.reject(new Error('WebSocket not connected'));
+            }
+        }
+    }
+
+    _handleMessage(data) {
+        // Subscription notification
+        if (data.method === 'subscription' && data.params) {
+            const subId = data.params.subscription;
+            const sub = this._subscriptions.get(subId);
+            if (sub) {
+                if (data.params.error) {
+                    sub._push('error', data.params.error);
+                    this._subscriptions.delete(subId);
+                } else if (data.params.complete) {
+                    sub._push('complete');
+                    this._subscriptions.delete(subId);
+                } else if (data.params.result !== undefined) {
+                    sub._push('item', data.params.result);
+                }
+            }
+            return;
+        }
+
+        // Server push notification (broadcast)
+        if (data.method && data.id === undefined) {
+            const listeners = this._listeners.get(data.method);
+            if (listeners) {
+                const result = data.params && data.params.result !== undefined
+                    ? data.params.result
+                    : data.params;
+                listeners.forEach(cb => cb(result));
+            }
+            return;
+        }
+
+        // Regular response
+        if (data.id !== undefined) {
+            const pending = this._pending.get(data.id);
+            if (pending) {
+                this._pending.delete(data.id);
+                if (data.error) {
+                    pending.reject(data.error);
+                } else {
+                    pending.resolve(data.result);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Represents an active streaming subscription.
+ * Register callbacks with onItem/onError/onComplete, cancel with cancel().
+ */
+export class Subscription {
+    _id = null;
+    _onItemCb = null;
+    _onErrorCb = null;
+    _onCompleteCb = null;
+    _client;
+    _buffer = [];
+
+    constructor(client) {
+        this._client = client;
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    onItem(callback) {
+        this._onItemCb = callback;
+        this._drain();
+        return this;
+    }
+
+    onError(callback) {
+        this._onErrorCb = callback;
+        this._drain();
+        return this;
+    }
+
+    onComplete(callback) {
+        this._onCompleteCb = callback;
+        this._drain();
+        return this;
+    }
+
+    _push(type, value) {
+        if (type === 'item' && this._onItemCb) {
+            this._onItemCb(value);
+        } else if (type === 'error' && this._onErrorCb) {
+            this._onErrorCb(value);
+        } else if (type === 'complete' && this._onCompleteCb) {
+            this._onCompleteCb();
+        } else {
+            this._buffer.push({ type, value });
+        }
+    }
+
+    _drain() {
+        const remaining = [];
+        for (const entry of this._buffer) {
+            if (entry.type === 'item' && this._onItemCb) {
+                this._onItemCb(entry.value);
+            } else if (entry.type === 'error' && this._onErrorCb) {
+                this._onErrorCb(entry.value);
+            } else if (entry.type === 'complete' && this._onCompleteCb) {
+                this._onCompleteCb();
+            } else {
+                remaining.push(entry);
+            }
+        }
+        this._buffer = remaining;
+    }
+
+    cancel() {
+        if (this._id) {
+            return this._client.unsubscribe(this._id);
+        }
+        return Promise.resolve(false);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ConflictingReturnTypeResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ConflictingReturnTypeResource.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.jsonrpc.app;
+
+import java.time.Duration;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Test resource with overloaded methods that have conflicting return types:
+ * one returns a plain value (call) and one returns Multi (subscribe).
+ * This should cause a build-time error when the JS client is enabled.
+ */
+@JsonRPCApi
+public class ConflictingReturnTypeResource {
+
+    public String data() {
+        return "plain";
+    }
+
+    public Multi<String> data(String filter) {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .onItem().transform(n -> "item " + n);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientConflictingReturnTypeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientConflictingReturnTypeTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.ConflictingReturnTypeResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JsClientConflictingReturnTypeTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ConflictingReturnTypeResource.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.client.enabled", "true")
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof IllegalArgumentException,
+                        "Expected IllegalArgumentException but got: " + t.getClass().getName());
+                Assertions.assertTrue(t.getMessage().contains("conflicting return types"),
+                        "Expected message about conflicting return types but got: " + t.getMessage());
+            });
+
+    @Test
+    public void testValidationFails() {
+        Assertions.fail("Should not reach here — build should have failed");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientDisabledTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientDisabledTest.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JsClientDisabledTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.client.enabled", "false");
+
+    @Test
+    public void testClientLibraryNotServedWhenDisabled() throws Exception {
+        int status = httpStatus("/_static/quarkus-json-rpc/jsonrpc-client.js");
+        Assertions.assertNotEquals(200, status,
+                "Client library should not be served when client generation is disabled");
+    }
+
+    @Test
+    public void testTypedProxyNotServedWhenDisabled() throws Exception {
+        int status = httpStatus("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
+        Assertions.assertNotEquals(200, status,
+                "Typed proxy should not be served when client generation is disabled");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkiverse.jsonrpc.app.Pojo;
+import io.quarkiverse.jsonrpc.app.Pojo2;
+import io.quarkiverse.jsonrpc.app.PojoResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JsClientGenerationTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.client.enabled", "true");
+
+    @Test
+    public void testClientLibraryIsServed() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc/jsonrpc-client.js");
+        Assertions.assertTrue(body.contains("export class JsonRPCClient"),
+                "Client library should contain JsonRPCClient class");
+        Assertions.assertTrue(body.contains("export class Subscription"),
+                "Client library should contain Subscription class");
+    }
+
+    @Test
+    public void testTypedProxyIsServed() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
+        Assertions.assertTrue(body.contains("import { JsonRPCClient } from '/_static/quarkus-json-rpc/jsonrpc-client.js'"),
+                "Proxy should import from absolute path");
+        Assertions.assertTrue(body.contains("export const client = new JsonRPCClient({ path: '/quarkus/json-rpc' })"),
+                "Proxy should export a client instance with configured path");
+    }
+
+    @Test
+    public void testProxyContainsScopeExports() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
+        Assertions.assertTrue(body.contains("export const HelloResource"),
+                "Proxy should export HelloResource scope");
+        Assertions.assertTrue(body.contains("export const PojoResource"),
+                "Proxy should export PojoResource scope");
+    }
+
+    @Test
+    public void testProxyUsesCallForRegularMethods() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
+        Assertions.assertTrue(body.contains("hello: (params) => client.call('HelloResource#hello'"),
+                "Regular methods should use client.call()");
+        Assertions.assertTrue(body.contains("helloUni: (params) => client.call('HelloResource#helloUni'"),
+                "Uni methods should use client.call()");
+    }
+
+    @Test
+    public void testProxyUsesSubscribeForStreamingMethods() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
+        Assertions.assertTrue(body.contains("helloMulti: (params) => client.subscribe('HelloResource#helloMulti'"),
+                "Multi methods should use client.subscribe()");
+        Assertions.assertTrue(body.contains("pojoMulti: (params) => client.subscribe('PojoResource#pojoMulti'"),
+                "Multi methods on PojoResource should use client.subscribe()");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientTestBase.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientTestBase.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+
+public abstract class JsClientTestBase {
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("/")
+    URI baseUri;
+
+    protected String httpGet(String path) throws Exception {
+        HttpClient client = vertx.createHttpClient();
+        try {
+            CompletableFuture<String> future = new CompletableFuture<>();
+            client.request(HttpMethod.GET, baseUri.getPort(), baseUri.getHost(), path)
+                    .onComplete(ar -> {
+                        if (ar.succeeded()) {
+                            ar.result().send().onComplete(respAr -> {
+                                if (respAr.succeeded()) {
+                                    var resp = respAr.result();
+                                    if (resp.statusCode() != 200) {
+                                        future.completeExceptionally(
+                                                new AssertionError(
+                                                        "Expected 200 for " + path + " but got " + resp.statusCode()));
+                                        return;
+                                    }
+                                    resp.body().onComplete(bodyAr -> {
+                                        if (bodyAr.succeeded()) {
+                                            future.complete(bodyAr.result().toString());
+                                        } else {
+                                            future.completeExceptionally(bodyAr.cause());
+                                        }
+                                    });
+                                } else {
+                                    future.completeExceptionally(respAr.cause());
+                                }
+                            });
+                        } else {
+                            future.completeExceptionally(ar.cause());
+                        }
+                    });
+            return future.get(10, TimeUnit.SECONDS);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    protected int httpStatus(String path) throws Exception {
+        HttpClient client = vertx.createHttpClient();
+        try {
+            CompletableFuture<Integer> future = new CompletableFuture<>();
+            client.request(HttpMethod.GET, baseUri.getPort(), baseUri.getHost(), path)
+                    .onComplete(ar -> {
+                        if (ar.succeeded()) {
+                            ar.result().send().onComplete(respAr -> {
+                                if (respAr.succeeded()) {
+                                    future.complete(respAr.result().statusCode());
+                                } else {
+                                    future.completeExceptionally(respAr.cause());
+                                }
+                            });
+                        } else {
+                            future.completeExceptionally(ar.cause());
+                        }
+                    });
+            return future.get(10, TimeUnit.SECONDS);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -6,6 +6,7 @@
 ** xref:guides-parameters.adoc[Parameters]
 ** xref:guides-streaming.adoc[Streaming with Multi]
 ** xref:guides-broadcasting.adoc[Broadcasting]
+** xref:guides-javascript-client.adoc[JavaScript Client]
 
 .Reference
 ** xref:reference-configuration.adoc[Configuration]

--- a/docs/modules/ROOT/pages/guides-javascript-client.adoc
+++ b/docs/modules/ROOT/pages/guides-javascript-client.adoc
@@ -1,0 +1,208 @@
+= JavaScript Client
+
+include::./includes/attributes.adoc[]
+
+When `quarkus.json-rpc.client.enabled` is set to `true`, the extension generates a JavaScript client library and a typed proxy module as web resources. These can be imported directly from frameworks like https://docs.quarkiverse.io/quarkus-web-bundler/dev/index.html[Quarkus Web Bundler] or https://quarkus.io/guides/web-dependency-locator[Web Dependency Locator] via the standard https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap[import map] convention.
+
+== Enabling the Client
+
+Add to `application.properties`:
+
+[source,properties]
+----
+quarkus.json-rpc.client.enabled=true
+----
+
+This generates three resources at build time:
+
+[cols="1,2"]
+|===
+| Resource | Purpose
+
+| `_static/quarkus-json-rpc/jsonrpc-client.js`
+| Reusable WebSocket client library
+
+| `_static/quarkus-json-rpc-api/jsonrpc-api.js`
+| Typed proxy with exports for each `@JsonRPCApi` scope
+
+| `META-INF/importmap.json`
+| Import map for module resolution
+|===
+
+== Using the Typed Proxy
+
+The generated proxy is the easiest way to call your JSON-RPC methods. It exports one object per `@JsonRPCApi` scope, plus the underlying `client` instance:
+
+[source,javascript]
+----
+import { client, GreetingService } from '@quarkiverse/json-rpc-api';
+
+// Simple call
+const greeting = await GreetingService.hello({ name: 'World' });
+console.log(greeting); // "Hello World"
+
+// With multiple parameters
+const full = await GreetingService.greet({ name: 'Jane', surname: 'Doe' });
+----
+
+Each method on the proxy accepts a params object (named parameters) or an array (positional parameters), matching the server-side Java method signature.
+
+=== Streaming Methods
+
+Methods that return `Multi<T>` or `Flow.Publisher<T>` on the server are automatically exposed as subscriptions:
+
+[source,javascript]
+----
+import { TickerService } from '@quarkiverse/json-rpc-api';
+
+const sub = TickerService.ticker()
+    .onItem(item => console.log('Received:', item))
+    .onError(err => console.error('Error:', err))
+    .onComplete(() => console.log('Stream completed'));
+
+// Cancel the subscription later
+await sub.cancel();
+----
+
+=== Configuring the Connection
+
+The typed proxy exports the `client` instance so you can reconfigure the WebSocket URL at runtime -- for example, when behind a reverse proxy or gateway:
+
+[source,javascript]
+----
+import { client, GreetingService } from '@quarkiverse/json-rpc-api';
+
+// Override the full URL
+client.url = 'wss://gateway.example.com/quarkus/json-rpc';
+
+// Or just change the path
+client.path = '/api/json-rpc';
+
+// Calls now go through the new URL
+const result = await GreetingService.hello({ name: 'World' });
+----
+
+== Using the Client Library Directly
+
+If you prefer more control, import the `JsonRPCClient` class directly:
+
+[source,javascript]
+----
+import { JsonRPCClient } from '@quarkiverse/json-rpc';
+
+const client = new JsonRPCClient({
+    path: '/quarkus/json-rpc',   // WebSocket path (default)
+    autoReconnect: true,         // Reconnect on disconnect (default)
+    maxReconnectDelay: 30000     // Max backoff in ms (default)
+});
+----
+
+=== Making Calls
+
+[source,javascript]
+----
+// Named parameters
+const result = await client.call('GreetingService#hello', { name: 'World' });
+
+// Positional parameters
+const result2 = await client.call('GreetingService#hello', ['World']);
+
+// No parameters
+const result3 = await client.call('GreetingService#hello');
+----
+
+=== Subscriptions
+
+[source,javascript]
+----
+const sub = client.subscribe('TickerService#ticker');
+sub.onItem(item => console.log(item));
+sub.onComplete(() => console.log('done'));
+sub.onError(err => console.error(err));
+
+// Cancel
+await sub.cancel();
+----
+
+=== Server Push Notifications
+
+Listen for notifications sent by `JsonRPCBroadcaster`:
+
+[source,javascript]
+----
+// Register a listener
+const off = client.on('update', data => {
+    console.log('Server push:', data);
+});
+
+// Remove the listener later
+off();
+----
+
+=== Connection Lifecycle
+
+[source,javascript]
+----
+const client = new JsonRPCClient({
+    autoConnect: false,  // Don't connect immediately
+    onOpen: () => console.log('Connected'),
+    onClose: () => console.log('Disconnected'),
+    onError: (err) => console.error('Error:', err)
+});
+
+// Connect manually
+client.connect();
+
+// Check connection state
+console.log(client.connected); // true or false
+
+// Disconnect (a subsequent connect() restores auto-reconnect)
+client.disconnect();
+----
+
+== Constructor Options
+
+[cols="1,1,1,2"]
+|===
+| Option | Type | Default | Description
+
+| `path`
+| `string`
+| `'/quarkus/json-rpc'`
+| WebSocket endpoint path
+
+| `url`
+| `string`
+| _derived from `location`_
+| Full WebSocket URL (overrides `path`)
+
+| `autoConnect`
+| `boolean`
+| `true`
+| Connect immediately on construction
+
+| `autoReconnect`
+| `boolean`
+| `true`
+| Reconnect automatically when the connection drops
+
+| `maxReconnectDelay`
+| `number`
+| `30000`
+| Maximum reconnect backoff delay in milliseconds
+
+| `onOpen`
+| `function`
+|
+| Called when the connection opens
+
+| `onClose`
+| `function`
+|
+| Called when the connection closes
+
+| `onError`
+| `function`
+|
+| Called on connection errors
+|===

--- a/docs/modules/ROOT/pages/includes/quarkus-json-rpc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-json-rpc.adoc
@@ -40,7 +40,24 @@ endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_JSON_RPC_WEB_SOCKET_PATH+++`
 endif::add-copy-button-to-env-var[]
---|string 
+--|string
 |`/quarkus/json-rpc`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-json-rpc_quarkus-json-rpc-client-enabled]]`link:#quarkus-json-rpc_quarkus-json-rpc-client-enabled[quarkus.json-rpc.client.enabled]`
+
+
+[.description]
+--
+Generate a JavaScript client proxy for all discovered JSON-RPC endpoints. When enabled, a static client library and a typed proxy module are generated as web resources, along with an import map following the mvnpm convention.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_JSON_RPC_CLIENT_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_JSON_RPC_CLIENT_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
 
 |===

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -73,6 +73,9 @@ Call methods with named parameters (JSON object) or positional parameters (JSON 
 POJO support::
 Complex types are serialized and deserialized automatically via Jackson, including nested objects, collections, and Java time types.
 
+JavaScript client::
+Optionally generate a typed JavaScript proxy for all your endpoints, ready to import from Quarkus Web Bundler or any ES module environment.
+
 Dev UI::
 An interactive method browser and tester is available in the Quarkus Dev UI during development.
 
@@ -96,6 +99,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 
 | xref:guides-broadcasting.adoc[Broadcasting]
 | Push notifications to clients from any CDI bean.
+
+| xref:guides-javascript-client.adoc[JavaScript Client]
+| Generate a typed JavaScript proxy for calling your endpoints from the browser.
 
 | xref:reference-configuration.adoc[Configuration Reference]
 | All available configuration properties.

--- a/sample/src/main/resources/application.properties
+++ b/sample/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.json-rpc.client.enabled=true

--- a/sample/src/main/resources/web/app/jsonrpc-app.js
+++ b/sample/src/main/resources/web/app/jsonrpc-app.js
@@ -4,11 +4,9 @@ class JsonRpcApp extends LitElement {
 
     static properties = {
         _connected: {state: true},
-        _method: {state: true},
-        _params: {state: true},
         _messages: {state: true},
-        _nextId: {state: true},
         _subscriptions: {state: true},
+        _ready: {state: true},
     };
 
     static styles = css`
@@ -73,23 +71,6 @@ class JsonRpcApp extends LitElement {
             color: #555;
         }
 
-        select, input, textarea {
-            width: 100%;
-            padding: 8px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-            font-family: inherit;
-            font-size: 0.9rem;
-            box-sizing: border-box;
-            margin-bottom: 12px;
-        }
-
-        textarea {
-            font-family: 'JetBrains Mono', 'Fira Code', monospace;
-            font-size: 0.8rem;
-            resize: vertical;
-        }
-
         .quick-methods {
             display: flex;
             flex-wrap: wrap;
@@ -114,6 +95,7 @@ class JsonRpcApp extends LitElement {
         .actions {
             display: flex;
             gap: 8px;
+            margin-top: 12px;
         }
 
         .actions button {
@@ -123,20 +105,6 @@ class JsonRpcApp extends LitElement {
             font-size: 0.9rem;
             font-weight: 500;
             cursor: pointer;
-        }
-
-        .btn-send {
-            background: #1976d2;
-            color: white;
-        }
-
-        .btn-send:hover {
-            background: #1565c0;
-        }
-
-        .btn-send:disabled {
-            background: #bbb;
-            cursor: not-allowed;
         }
 
         .btn-clear {
@@ -238,51 +206,26 @@ class JsonRpcApp extends LitElement {
 
     constructor() {
         super();
-        this._ws = null;
         this._connected = false;
-        this._method = 'HelloResource#hello';
-        this._params = '';
         this._messages = [];
-        this._nextId = 1;
         this._subscriptions = new Map();
+        this._ready = false;
+        this._rpc = null;
     }
 
-    connectedCallback() {
+    async connectedCallback() {
         super.connectedCallback();
-        this._connect();
-    }
-
-    disconnectedCallback() {
-        super.disconnectedCallback();
-        if (this._ws) this._ws.close();
-    }
-
-    _connect() {
-        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const ws = new WebSocket(`${protocol}//${location.host}/quarkus/json-rpc`);
-
-        ws.onopen = () => {
-            this._connected = true;
-            this._ws = ws;
-        };
-
-        ws.onclose = () => {
+        // Load the generated JSON-RPC proxy at runtime (dynamic path prevents esbuild resolution)
+        const apiPath = ['/_static/quarkus-json-rpc-api', 'jsonrpc-api.js'].join('/');
+        const rpc = await import(apiPath);
+        this._rpc = rpc;
+        rpc.client.onOpen = () => { this._connected = true; };
+        rpc.client.onClose = () => {
             this._connected = false;
-            this._ws = null;
             this._subscriptions = new Map();
-            setTimeout(() => this._connect(), 2000);
         };
-
-        ws.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            if (data.method === 'subscription') {
-                this._addMessage('notification', data);
-            } else if (data.error && data.error.message) {
-                this._addMessage('error', data);
-            } else {
-                this._addMessage('received', data);
-            }
-        };
+        this._connected = rpc.client.connected;
+        this._ready = true;
     }
 
     _addMessage(type, data) {
@@ -294,51 +237,43 @@ class JsonRpcApp extends LitElement {
         });
     }
 
-    _send() {
-        if (!this._ws) return;
-
-        const id = this._nextId++;
-        const req = {jsonrpc: '2.0', method: this._method, id};
-
-        const paramsText = this._params.trim();
-        if (paramsText) {
-            try {
-                req.params = JSON.parse(paramsText);
-            } catch {
-                this._addMessage('error', {error: {message: 'Invalid JSON in params field'}});
-                return;
-            }
+    async _call(label, fn) {
+        this._addMessage('sent', {call: label});
+        try {
+            const result = await fn();
+            this._addMessage('received', {result});
+        } catch (err) {
+            this._addMessage('error', {error: err});
         }
-
-        this._addMessage('sent', req);
-        this._ws.send(JSON.stringify(req));
-
-        // Track subscription acks
-        const handler = (event) => {
-            const data = JSON.parse(event.data);
-            if (data.id === id && data.result && typeof data.result === 'string'
-                && data.result.match(/^[0-9a-f]{8}-/)) {
-                this._subscriptions = new Map([...this._subscriptions, [data.result, this._method]]);
-                this._ws.removeEventListener('message', handler);
-            }
-        };
-        this._ws.addEventListener('message', handler);
     }
 
-    _unsubscribe(subscriptionId) {
-        if (!this._ws) return;
-        const id = this._nextId++;
-        const req = {jsonrpc: '2.0', method: 'unsubscribe', params: {subscription: subscriptionId}, id};
-        this._addMessage('sent', req);
-        this._ws.send(JSON.stringify(req));
+    _subscribe(label, fn) {
+        this._addMessage('sent', {subscribe: label});
+        const sub = fn()
+            .onItem(item => this._addMessage('notification', {subscription: label, item}))
+            .onError(err => {
+                this._addMessage('error', {subscription: label, error: err});
+                this._removeSubscription(label);
+            })
+            .onComplete(() => {
+                this._addMessage('notification', {subscription: label, complete: true});
+                this._removeSubscription(label);
+            });
+        this._subscriptions = new Map([...this._subscriptions, [label, sub]]);
+    }
+
+    _removeSubscription(label) {
         const subs = new Map(this._subscriptions);
-        subs.delete(subscriptionId);
+        subs.delete(label);
         this._subscriptions = subs;
     }
 
-    _selectMethod(method, params) {
-        this._method = method;
-        this._params = params || '';
+    async _unsubscribe(label) {
+        const sub = this._subscriptions.get(label);
+        if (sub) {
+            await sub.cancel();
+            this._removeSubscription(label);
+        }
     }
 
     _clearMessages() {
@@ -356,7 +291,6 @@ class JsonRpcApp extends LitElement {
         while (i < str.length) {
             const ch = str[i];
             if (ch === '"') {
-                // Find end of string
                 let j = i + 1;
                 while (j < str.length) {
                     if (str[j] === '\\') { j += 2; continue; }
@@ -364,7 +298,6 @@ class JsonRpcApp extends LitElement {
                     j++;
                 }
                 const s = str.slice(i, j);
-                // Check if this is a key (followed by colon)
                 let k = j;
                 while (k < str.length && str[k] === ' ') k++;
                 if (str[k] === ':') {
@@ -397,22 +330,31 @@ class JsonRpcApp extends LitElement {
     }
 
     render() {
-        const quickMethods = [
-            ['HelloResource#hello', ''],
-            ['HelloResource#hello', '{"name": "World"}'],
-            ['HelloResource#hello', '{"name": "John", "surname": "Doe"}'],
-            ['HelloResource#helloNonBlocking', '{"name": "World"}'],
-            ['HelloResource#helloUni', '{"name": "Async"}'],
-            ['HelloResource#helloUniBlocking', '{"name": "Blocking"}'],
-            ['HelloResource#helloMulti', '{"name": "Stream"}'],
-            ['HelloResource#helloMulti', ''],
-            ['PojoResource#pojo', ''],
-            ['PojoResource#pojo', '{"name": "John", "surname": "Doe"}'],
-            ['PojoResource#pojoUni', ''],
-            ['PojoResource#pojoMulti', ''],
-            ['scoped#hello', ''],
-            ['scoped#hello', '{"name": "World"}'],
-            ['scoped#pojo', ''],
+        if (!this._ready) {
+            return html`<h1>Loading...</h1>`;
+        }
+
+        const {HelloResource, PojoResource, scoped} = this._rpc;
+
+        const calls = [
+            ['HelloResource.hello()', () => HelloResource.hello()],
+            ['HelloResource.hello({name})', () => HelloResource.hello({name: 'World'})],
+            ['HelloResource.hello({name, surname})', () => HelloResource.hello({name: 'John', surname: 'Doe'})],
+            ['HelloResource.helloNonBlocking({name})', () => HelloResource.helloNonBlocking({name: 'World'})],
+            ['HelloResource.helloUni({name})', () => HelloResource.helloUni({name: 'Async'})],
+            ['HelloResource.helloUniBlocking({name})', () => HelloResource.helloUniBlocking({name: 'Blocking'})],
+            ['PojoResource.pojo()', () => PojoResource.pojo()],
+            ['PojoResource.pojo({name, surname})', () => PojoResource.pojo({name: 'John', surname: 'Doe'})],
+            ['PojoResource.pojoUni()', () => PojoResource.pojoUni()],
+            ['scoped.hello()', () => scoped.hello()],
+            ['scoped.hello({name})', () => scoped.hello({name: 'World'})],
+            ['scoped.pojo()', () => scoped.pojo()],
+        ];
+
+        const streams = [
+            ['HelloResource.helloMulti()', () => HelloResource.helloMulti()],
+            ['HelloResource.helloMulti({name})', () => HelloResource.helloMulti({name: 'Stream'})],
+            ['PojoResource.pojoMulti()', () => PojoResource.pojoMulti()],
         ];
 
         return html`
@@ -424,41 +366,39 @@ class JsonRpcApp extends LitElement {
 
             <div class="layout">
                 <div class="panel">
-                    <h2>Request</h2>
-
-                    <label>Quick methods</label>
+                    <h2>RPC Calls</h2>
+                    <label>Click a method to invoke it</label>
                     <div class="quick-methods">
-                        ${quickMethods.map(([m, p]) => {
-                            const label = p ? `${m}(${Object.keys(JSON.parse(p)).join(', ')})` : `${m}()`;
-                            return html`<button @click=${() => this._selectMethod(m, p)}>${label}</button>`;
-                        })}
+                        ${calls.map(([label, fn]) =>
+                            html`<button ?disabled=${!this._connected}
+                                         @click=${() => this._call(label, fn)}>${label}</button>`
+                        )}
                     </div>
 
-                    <label>Method</label>
-                    <input type="text" .value=${this._method}
-                        @input=${e => this._method = e.target.value}>
-
-                    <label>Params (JSON)</label>
-                    <textarea rows="3" .value=${this._params}
-                        @input=${e => this._params = e.target.value}
-                        placeholder='{"name": "value"} or ["value1", "value2"]'></textarea>
-
-                    <div class="actions">
-                        <button class="btn-send" ?disabled=${!this._connected} @click=${this._send}>Send</button>
-                        <button class="btn-clear" @click=${this._clearMessages}>Clear</button>
+                    <h2>Streaming</h2>
+                    <label>Subscribe to a Multi stream</label>
+                    <div class="quick-methods">
+                        ${streams.map(([label, fn]) =>
+                            html`<button ?disabled=${!this._connected}
+                                         @click=${() => this._subscribe(label, fn)}>${label}</button>`
+                        )}
                     </div>
 
                     ${this._subscriptions.size > 0 ? html`
                         <div class="subscriptions">
                             <label>Active subscriptions</label>
-                            ${[...this._subscriptions.entries()].map(([id, method]) => html`
+                            ${[...this._subscriptions.keys()].map(label => html`
                                 <div class="sub-item">
-                                    <span>${method} (${id.substring(0, 8)}...)</span>
-                                    <button @click=${() => this._unsubscribe(id)}>Unsubscribe</button>
+                                    <span>${label}</span>
+                                    <button @click=${() => this._unsubscribe(label)}>Unsubscribe</button>
                                 </div>
                             `)}
                         </div>
                     ` : ''}
+
+                    <div class="actions">
+                        <button class="btn-clear" @click=${this._clearMessages}>Clear Messages</button>
+                    </div>
                 </div>
 
                 <div class="panel">


### PR DESCRIPTION
When `quarkus.json-rpc.client.enabled=true` (default `false`), the build generates a JavaScript client library and typed proxy module as web resources, along with an import map following the mvnpm convention.

### Generated resources

| Resource | Purpose |
|---|---|
| `/_static/quarkus-json-rpc/jsonrpc-client.js` | Reusable WebSocket client with Promise-based `call()`, streaming `subscribe()`, and broadcast `on()` |
| `/_static/quarkus-json-rpc-api/jsonrpc-api.js` | Typed proxy with exports per `@JsonRPCApi` scope — `call()` for regular/Uni methods, `subscribe()` for Multi/Flow.Publisher |
| `META-INF/importmap.json` | Import map for `@quarkiverse/json-rpc` and `@quarkiverse/json-rpc-api` module resolution |

### Client features

- Configurable WebSocket URL (constructor, runtime setter) for proxy/gateway scenarios
- Auto-reconnect with exponential backoff
- Request/response correlation via auto-incrementing IDs
- Subscription lifecycle (ACK → items → complete/error → cancel)
- Server push listener for `JsonRPCBroadcaster` notifications

### Web-bundler note

Web-bundler's esbuild resolution only discovers dependencies from `org.mvnpm` / `org.webjars.npm` groups, so the generated import map isn't picked up at bundle time. The sample app uses a dynamic `import()` as a workaround. Filed quarkiverse/quarkus-web-bundler#425 to support `META-INF/importmap.json` from arbitrary JARs.

Closes #10