### PR TITLE
feat: add security support for JSON-RPC endpoints

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -524,35 +524,18 @@ public class JsonRPCProcessor {
         return "";
     }
 
-    private String getSecurityLabel(MethodInfo method) {
-        if (method.hasAnnotation(ROLES_ALLOWED)) {
-            AnnotationInstance ann = method.annotation(ROLES_ALLOWED);
+    private String getSecurityLabel(AnnotationTarget target) {
+        if (target.hasAnnotation(ROLES_ALLOWED)) {
+            AnnotationInstance ann = target.annotation(ROLES_ALLOWED);
             return "@RolesAllowed(" + formatRoles(ann) + ")";
         }
-        if (method.hasAnnotation(PERMIT_ALL)) {
+        if (target.hasAnnotation(PERMIT_ALL)) {
             return "@PermitAll";
         }
-        if (method.hasAnnotation(DENY_ALL)) {
+        if (target.hasAnnotation(DENY_ALL)) {
             return "@DenyAll";
         }
-        if (method.hasAnnotation(AUTHENTICATED)) {
-            return "@Authenticated";
-        }
-        return null;
-    }
-
-    private String getSecurityLabel(ClassInfo classInfo) {
-        if (classInfo.hasAnnotation(ROLES_ALLOWED)) {
-            AnnotationInstance ann = classInfo.annotation(ROLES_ALLOWED);
-            return "@RolesAllowed(" + formatRoles(ann) + ")";
-        }
-        if (classInfo.hasAnnotation(PERMIT_ALL)) {
-            return "@PermitAll";
-        }
-        if (classInfo.hasAnnotation(DENY_ALL)) {
-            return "@DenyAll";
-        }
-        if (classInfo.hasAnnotation(AUTHENTICATED)) {
+        if (target.hasAnnotation(AUTHENTICATED)) {
             return "@Authenticated";
         }
         return null;

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -392,9 +392,16 @@ public class JsonRPCProcessor {
 
     // Dev UI
 
+    private static final DotName ROLES_ALLOWED = DotName.createSimple("jakarta.annotation.security.RolesAllowed");
+    private static final DotName PERMIT_ALL = DotName.createSimple("jakarta.annotation.security.PermitAll");
+    private static final DotName DENY_ALL = DotName.createSimple("jakarta.annotation.security.DenyAll");
+    private static final DotName AUTHENTICATED = DotName.createSimple("io.quarkus.security.Authenticated");
+
     @BuildStep(onlyIf = IsLocalDevelopment.class)
-    CardPageBuildItem createDevUICard(JsonRPCConfig jsonRPCConfig, JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem) {
+    CardPageBuildItem createDevUICard(JsonRPCConfig jsonRPCConfig, JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
+            CombinedIndexBuildItem combinedIndexBuildItem) {
         CardPageBuildItem card = new CardPageBuildItem();
+        IndexView index = combinedIndexBuildItem.getIndex();
 
         // Build-time data: registered methods table
         List<Map<String, Object>> methodsList = new ArrayList<>();
@@ -427,10 +434,13 @@ public class JsonRPCProcessor {
             }
             methodData.put("executionMode", execMode);
 
+            // Detect security annotations
+            methodData.put("security", resolveSecurityConstraint(index, method));
+
             methodsList.add(methodData);
         }
         card.addBuildTimeData("methods", methodsList,
-                "All registered JSON-RPC methods with their signatures and execution modes", true);
+                "All registered JSON-RPC methods with their signatures, execution modes, and security constraints", true);
         card.addBuildTimeData("endpointPath", jsonRPCConfig.webSocket().path(),
                 "The WebSocket endpoint path for JSON-RPC connections", true);
 
@@ -471,6 +481,90 @@ public class JsonRPCProcessor {
                 .enableMcpFuctionByDefault()
                 .build();
         return actions;
+    }
+
+    /**
+     * Resolve the effective security constraint for a JSON-RPC method by checking
+     * for security annotations on the method first, then falling back to the class.
+     *
+     * @return a human-readable security label, or empty string if unsecured
+     */
+    private String resolveSecurityConstraint(IndexView index, JsonRPCMethod method) {
+        ClassInfo classInfo = index.getClassByName(method.getClazz().getName());
+        if (classInfo == null) {
+            return "";
+        }
+
+        // Find the matching method in the Jandex index
+        MethodInfo methodInfo = null;
+        for (MethodInfo mi : classInfo.methods()) {
+            if (mi.name().equals(method.getMethodName())) {
+                int paramCount = method.hasParams() ? method.getParams().size() : 0;
+                if (mi.parametersCount() == paramCount) {
+                    methodInfo = mi;
+                    break;
+                }
+            }
+        }
+
+        // Check method-level annotations first (they override class-level)
+        if (methodInfo != null) {
+            String methodSecurity = getSecurityLabel(methodInfo);
+            if (methodSecurity != null) {
+                return methodSecurity;
+            }
+        }
+
+        // Fall back to class-level annotations
+        String classSecurity = getSecurityLabel(classInfo);
+        if (classSecurity != null) {
+            return classSecurity;
+        }
+
+        return "";
+    }
+
+    private String getSecurityLabel(MethodInfo method) {
+        if (method.hasAnnotation(ROLES_ALLOWED)) {
+            AnnotationInstance ann = method.annotation(ROLES_ALLOWED);
+            return "@RolesAllowed(" + formatRoles(ann) + ")";
+        }
+        if (method.hasAnnotation(PERMIT_ALL)) {
+            return "@PermitAll";
+        }
+        if (method.hasAnnotation(DENY_ALL)) {
+            return "@DenyAll";
+        }
+        if (method.hasAnnotation(AUTHENTICATED)) {
+            return "@Authenticated";
+        }
+        return null;
+    }
+
+    private String getSecurityLabel(ClassInfo classInfo) {
+        if (classInfo.hasAnnotation(ROLES_ALLOWED)) {
+            AnnotationInstance ann = classInfo.annotation(ROLES_ALLOWED);
+            return "@RolesAllowed(" + formatRoles(ann) + ")";
+        }
+        if (classInfo.hasAnnotation(PERMIT_ALL)) {
+            return "@PermitAll";
+        }
+        if (classInfo.hasAnnotation(DENY_ALL)) {
+            return "@DenyAll";
+        }
+        if (classInfo.hasAnnotation(AUTHENTICATED)) {
+            return "@Authenticated";
+        }
+        return null;
+    }
+
+    private String formatRoles(AnnotationInstance rolesAllowed) {
+        AnnotationValue value = rolesAllowed.value();
+        if (value == null) {
+            return "";
+        }
+        String[] roles = value.asStringArray();
+        return String.join(", ", roles);
     }
 
     private static final Set<String> NON_STREAMING_REACTIVE_TYPES = Set.of(

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
@@ -26,6 +26,21 @@ export class QwcJsonRpcMethods extends LitElement {
         .action-link:hover {
             text-decoration: underline;
         }
+        .security-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 0.8em;
+            font-weight: 500;
+        }
+        .security-badge.secured {
+            background: var(--lumo-primary-color-10pct, #e3f2fd);
+            color: var(--lumo-primary-text-color, #1565c0);
+        }
+        .security-badge.unsecured {
+            color: var(--lumo-secondary-text-color, #999);
+            font-style: italic;
+        }
     `;
 
     render() {
@@ -36,6 +51,12 @@ export class QwcJsonRpcMethods extends LitElement {
                 <vaadin-grid-sort-column path="methodName" header="Method" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="parameters" header="Parameters" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="executionMode" header="Execution Mode" auto-width resizable></vaadin-grid-sort-column>
+                <vaadin-grid-column header="Security" auto-width resizable
+                    ${columnBodyRenderer((item) => item.security
+                        ? html`<span class="security-badge secured">${item.security}</span>`
+                        : html`<span class="security-badge unsecured">none</span>`
+                    , [])}>
+                </vaadin-grid-column>
                 <vaadin-grid-column
                     frozen-to-end
                     auto-width

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
@@ -78,6 +78,15 @@ export class QwcJsonRpcTester extends LitElement {
             font-size: 0.85em;
             color: var(--lumo-secondary-text-color);
         }
+        .security-info {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-size: 0.85em;
+            font-weight: 500;
+            background: var(--lumo-primary-color-10pct, #e3f2fd);
+            color: var(--lumo-primary-text-color, #1565c0);
+        }
     `;
 
     static properties = {
@@ -132,6 +141,13 @@ export class QwcJsonRpcTester extends LitElement {
                     `)}
                 </select>
             </div>
+
+            ${this._selectedMethod?.security ? html`
+                <div class="form-row">
+                    <label>Security:</label>
+                    <span class="security-info">${this._selectedMethod.security}</span>
+                </div>
+            ` : ''}
 
             ${this._selectedMethod?.parameters?.length > 0 ?
                 this._selectedMethod.parameters.split(', ').map(p => {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/SecuredResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/SecuredResource.java
@@ -1,9 +1,11 @@
 package io.quarkiverse.jsonrpc.app;
 
+import jakarta.annotation.security.DenyAll;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.quarkus.security.Authenticated;
 
 @JsonRPCApi
 @RolesAllowed("admin")
@@ -25,5 +27,15 @@ public class SecuredResource {
     @RolesAllowed("user")
     public String userInfo() {
         return "user-info";
+    }
+
+    @DenyAll
+    public String denied() {
+        return "should-never-be-returned";
+    }
+
+    @Authenticated
+    public String authenticatedOnly() {
+        return "authenticated-info";
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/SecuredResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/SecuredResource.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.app;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+@RolesAllowed("admin")
+public class SecuredResource {
+
+    public String adminOnly() {
+        return "admin-secret";
+    }
+
+    public String adminData(String key) {
+        return "admin:" + key;
+    }
+
+    @PermitAll
+    public String publicInfo() {
+        return "public-info";
+    }
+
+    @RolesAllowed("user")
+    public String userInfo() {
+        return "user-info";
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityHttpPolicyJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityHttpPolicyJsonRpcTest.java
@@ -1,0 +1,136 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests that standard Quarkus HTTP auth policies ({@code quarkus.http.auth.permission.*})
+ * can be used to secure the WebSocket upgrade for the JSON-RPC endpoint.
+ * <p>
+ * No security annotations are used on the {@link HelloResource} itself — security is
+ * applied purely via configuration on the endpoint path.
+ */
+public class SecurityHttpPolicyJsonRpcTest {
+
+    private final AtomicInteger count = new AtomicInteger(0);
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class);
+                root.addAsResource(new org.jboss.shrinkwrap.api.asset.StringAsset(
+                        "quarkus.http.auth.basic=true\n" +
+                                "quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc\n" +
+                                "quarkus.http.auth.permission.json-rpc.policy=authenticated\n" +
+                                "quarkus.security.users.embedded.enabled=true\n" +
+                                "quarkus.security.users.embedded.plain-text=true\n" +
+                                "quarkus.security.users.embedded.users.admin=admin\n" +
+                                "quarkus.security.users.embedded.roles.admin=admin\n"),
+                        "application.properties");
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("quarkus/json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testAuthenticatedUserCanConnect() throws Exception {
+        JsonObject response = callWithAuth("HelloResource#hello", "admin", "admin");
+        Assertions.assertNull(response.getJsonObject("error"), "Expected successful response");
+        String result = response.getString("result");
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.startsWith("Hello ["), result);
+    }
+
+    @Test
+    public void testUnauthenticatedUserIsRejected() throws Exception {
+        int id = count.incrementAndGet();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+
+            // Connect WITHOUT credentials
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setPort(jsonRpcUri.getPort())
+                    .setHost(jsonRpcUri.getHost())
+                    .setURI(jsonRpcUri.getPath());
+
+            client.connect(options)
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            // Should not succeed — security should reject
+                            message.add("UNEXPECTED_SUCCESS");
+                        } else {
+                            // Expected: connection rejected
+                            message.add("REJECTED:" + r.cause().getMessage());
+                        }
+                    });
+
+            String result = message.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(result, "No response received within timeout");
+            Assertions.assertTrue(result.startsWith("REJECTED:"),
+                    "Expected WebSocket upgrade to be rejected without credentials, got: " + result);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private JsonObject callWithAuth(String method, String username, String password) throws Exception {
+        int id = count.incrementAndGet();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+
+            String credentials = Base64.getEncoder()
+                    .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setPort(jsonRpcUri.getPort())
+                    .setHost(jsonRpcUri.getHost())
+                    .setURI(jsonRpcUri.getPath())
+                    .addHeader("Authorization", "Basic " + credentials);
+
+            client.connect(options)
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            ws.textMessageHandler(msg -> message.add(msg));
+
+                            JsonObject jsonObject = JsonObject.of("jsonrpc", "2.0", "id", id, "method", method);
+                            ws.writeTextMessage(jsonObject.encodePrettily());
+                        } else {
+                            message.add("{\"id\":" + id
+                                    + ",\"error\":{\"code\":-32000,\"message\":\"" + r.cause().getMessage() + "\"}}");
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return Json.decodeValue(response, JsonObject.class);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityHttpPolicyJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityHttpPolicyJsonRpcTest.java
@@ -66,7 +66,6 @@ public class SecurityHttpPolicyJsonRpcTest {
 
     @Test
     public void testUnauthenticatedUserIsRejected() throws Exception {
-        int id = count.incrementAndGet();
         WebSocketClient client = vertx.createWebSocketClient();
         try {
             LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityJsonRpcTest.java
@@ -107,6 +107,57 @@ public class SecurityJsonRpcTest {
         Assertions.assertEquals(-32001, code, "Expected FORBIDDEN error code");
     }
 
+    // --- @DenyAll override tests ---
+
+    @Test
+    public void testAdminCannotAccessDenyAllMethod() throws Exception {
+        JsonObject response = callWithAuthRaw("SecuredResource#denied", "admin", "admin");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for @DenyAll method");
+        int code = response.getJsonObject("error").getInteger("code");
+        Assertions.assertEquals(-32001, code, "Expected FORBIDDEN error code");
+    }
+
+    @Test
+    public void testUserCannotAccessDenyAllMethod() throws Exception {
+        JsonObject response = callWithAuthRaw("SecuredResource#denied", "user", "user");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for @DenyAll method");
+        int code = response.getJsonObject("error").getInteger("code");
+        Assertions.assertEquals(-32001, code, "Expected FORBIDDEN error code");
+    }
+
+    // --- @Authenticated override tests ---
+
+    @Test
+    public void testAdminCanAccessAuthenticatedMethod() throws Exception {
+        String result = callWithAuth("SecuredResource#authenticatedOnly", "admin", "admin");
+        Assertions.assertEquals("authenticated-info", result);
+    }
+
+    @Test
+    public void testUserCanAccessAuthenticatedMethod() throws Exception {
+        String result = callWithAuth("SecuredResource#authenticatedOnly", "user", "user");
+        Assertions.assertEquals("authenticated-info", result);
+    }
+
+    // --- Anonymous user tests ---
+
+    @Test
+    public void testAnonymousCanAccessPermitAllMethod() throws Exception {
+        JsonObject response = callAnonymousRaw("SecuredResource#publicInfo");
+        Assertions.assertNull(response.getJsonObject("error"), "Expected successful response for @PermitAll");
+        Assertions.assertEquals("public-info", response.getString("result"));
+    }
+
+    @Test
+    public void testAnonymousCannotAccessAdminMethod() throws Exception {
+        JsonObject response = callAnonymousRaw("SecuredResource#adminOnly");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for anonymous user");
+        int code = response.getJsonObject("error").getInteger("code");
+        // Anonymous is either unauthorized or forbidden depending on interceptor behavior
+        Assertions.assertTrue(code == -32000 || code == -32001,
+                "Expected UNAUTHORIZED or FORBIDDEN error code, got: " + code);
+    }
+
     // --- Helper methods ---
 
     private String callWithAuth(String method, String username, String password) throws Exception {
@@ -116,9 +167,9 @@ public class SecurityJsonRpcTest {
     private String callWithAuth(String method, String username, String password, Map<String, Object> params)
             throws Exception {
         JsonObject response = callWithAuthRaw(method, username, password, params);
-        String error = response.getString("error");
+        JsonObject error = response.getJsonObject("error");
         if (error != null) {
-            Assertions.fail("Unexpected error: " + error);
+            Assertions.fail("Unexpected error: " + error.encodePrettily());
         }
         return response.getString("result");
     }
@@ -156,6 +207,40 @@ public class SecurityJsonRpcTest {
                             ws.writeTextMessage(jsonObject.encodePrettily());
                         } else {
                             // Connection rejected (e.g., 401/403 during upgrade)
+                            message.add("{\"id\":" + id
+                                    + ",\"error\":{\"code\":-32000,\"message\":\"WebSocket upgrade rejected: "
+                                    + r.cause().getMessage() + "\"}}");
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return Json.decodeValue(response, JsonObject.class);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private JsonObject callAnonymousRaw(String method) throws Exception {
+        int id = count.incrementAndGet();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setPort(jsonRpcUri.getPort())
+                    .setHost(jsonRpcUri.getHost())
+                    .setURI(jsonRpcUri.getPath());
+
+            client.connect(options)
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            ws.textMessageHandler(msg -> message.add(msg));
+
+                            JsonObject jsonObject = JsonObject.of("jsonrpc", "2.0", "id", id, "method", method);
+                            ws.writeTextMessage(jsonObject.encodePrettily());
+                        } else {
                             message.add("{\"id\":" + id
                                     + ",\"error\":{\"code\":-32000,\"message\":\"WebSocket upgrade rejected: "
                                     + r.cause().getMessage() + "\"}}");

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityJsonRpcTest.java
@@ -1,0 +1,172 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.SecuredResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests security annotations on @JsonRPCApi classes.
+ * <p>
+ * The {@link SecuredResource} is annotated with {@code @RolesAllowed("admin")} at the class level,
+ * individual methods override with {@code @PermitAll} or {@code @RolesAllowed("user")}.
+ */
+public class SecurityJsonRpcTest {
+
+    private final AtomicInteger count = new AtomicInteger(0);
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(SecuredResource.class);
+                root.addAsResource(new org.jboss.shrinkwrap.api.asset.StringAsset(
+                        "quarkus.http.auth.basic=true\n" +
+                                "quarkus.security.users.embedded.enabled=true\n" +
+                                "quarkus.security.users.embedded.plain-text=true\n" +
+                                "quarkus.security.users.embedded.users.admin=admin\n" +
+                                "quarkus.security.users.embedded.roles.admin=admin\n" +
+                                "quarkus.security.users.embedded.users.user=user\n" +
+                                "quarkus.security.users.embedded.roles.user=user\n"),
+                        "application.properties");
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("quarkus/json-rpc")
+    URI jsonRpcUri;
+
+    // --- Admin role tests ---
+
+    @Test
+    public void testAdminCanAccessAdminMethod() throws Exception {
+        String result = callWithAuth("SecuredResource#adminOnly", "admin", "admin");
+        Assertions.assertEquals("admin-secret", result);
+    }
+
+    @Test
+    public void testAdminCanAccessAdminMethodWithParams() throws Exception {
+        String result = callWithAuth("SecuredResource#adminData", "admin", "admin", Map.of("key", "test"));
+        Assertions.assertEquals("admin:test", result);
+    }
+
+    @Test
+    public void testUserCannotAccessAdminMethod() throws Exception {
+        JsonObject response = callWithAuthRaw("SecuredResource#adminOnly", "user", "user");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for unauthorized user");
+        int code = response.getJsonObject("error").getInteger("code");
+        Assertions.assertEquals(-32001, code, "Expected FORBIDDEN error code");
+    }
+
+    // --- @PermitAll override tests ---
+
+    @Test
+    public void testAdminCanAccessPermitAllMethod() throws Exception {
+        String result = callWithAuth("SecuredResource#publicInfo", "admin", "admin");
+        Assertions.assertEquals("public-info", result);
+    }
+
+    @Test
+    public void testUserCanAccessPermitAllMethod() throws Exception {
+        String result = callWithAuth("SecuredResource#publicInfo", "user", "user");
+        Assertions.assertEquals("public-info", result);
+    }
+
+    // --- @RolesAllowed("user") method-level override tests ---
+
+    @Test
+    public void testUserCanAccessUserMethod() throws Exception {
+        String result = callWithAuth("SecuredResource#userInfo", "user", "user");
+        Assertions.assertEquals("user-info", result);
+    }
+
+    @Test
+    public void testAdminCannotAccessUserMethod() throws Exception {
+        JsonObject response = callWithAuthRaw("SecuredResource#userInfo", "admin", "admin");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for admin on user-only method");
+        int code = response.getJsonObject("error").getInteger("code");
+        Assertions.assertEquals(-32001, code, "Expected FORBIDDEN error code");
+    }
+
+    // --- Helper methods ---
+
+    private String callWithAuth(String method, String username, String password) throws Exception {
+        return callWithAuth(method, username, password, Map.of());
+    }
+
+    private String callWithAuth(String method, String username, String password, Map<String, Object> params)
+            throws Exception {
+        JsonObject response = callWithAuthRaw(method, username, password, params);
+        String error = response.getString("error");
+        if (error != null) {
+            Assertions.fail("Unexpected error: " + error);
+        }
+        return response.getString("result");
+    }
+
+    private JsonObject callWithAuthRaw(String method, String username, String password) throws Exception {
+        return callWithAuthRaw(method, username, password, Map.of());
+    }
+
+    private JsonObject callWithAuthRaw(String method, String username, String password, Map<String, Object> params)
+            throws Exception {
+        int id = count.incrementAndGet();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+
+            String credentials = Base64.getEncoder()
+                    .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setPort(jsonRpcUri.getPort())
+                    .setHost(jsonRpcUri.getHost())
+                    .setURI(jsonRpcUri.getPath())
+                    .addHeader("Authorization", "Basic " + credentials);
+
+            client.connect(options)
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            ws.textMessageHandler(msg -> message.add(msg));
+
+                            JsonObject jsonObject = JsonObject.of("jsonrpc", "2.0", "id", id, "method", method);
+                            if (params != null && !params.isEmpty()) {
+                                jsonObject.put("params", JsonObject.mapFrom(params));
+                            }
+                            ws.writeTextMessage(jsonObject.encodePrettily());
+                        } else {
+                            // Connection rejected (e.g., 401/403 during upgrade)
+                            message.add("{\"id\":" + id
+                                    + ",\"error\":{\"code\":-32000,\"message\":\"WebSocket upgrade rejected: "
+                                    + r.cause().getMessage() + "\"}}");
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return Json.decodeValue(response, JsonObject.class);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -6,6 +6,7 @@
 ** xref:guides-parameters.adoc[Parameters]
 ** xref:guides-streaming.adoc[Streaming with Multi]
 ** xref:guides-broadcasting.adoc[Broadcasting]
+** xref:guides-security.adoc[Security]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 
 .Reference

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -7,6 +7,7 @@
 ** xref:guides-streaming.adoc[Streaming with Multi]
 ** xref:guides-broadcasting.adoc[Broadcasting]
 ** xref:guides-security.adoc[Security]
+** xref:guides-concurrency.adoc[Concurrency & Session Isolation]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 
 .Reference

--- a/docs/modules/ROOT/pages/guides-concurrency.adoc
+++ b/docs/modules/ROOT/pages/guides-concurrency.adoc
@@ -1,0 +1,103 @@
+= Concurrency & Session Isolation
+
+include::./includes/attributes.adoc[]
+
+When multiple users connect to your JSON-RPC WebSocket endpoint simultaneously, each connection is fully isolated and the backend is designed to handle concurrent load efficiently.
+
+== Connection Isolation
+
+Each WebSocket connection is independent. The extension tracks every connection as a separate session with its own unique ID. This means:
+
+- **Requests and responses are scoped to a single connection** — a response is always sent back to the socket that made the request, never to another user.
+- **Streaming subscriptions (`Multi<T>`) are per-connection** — each client manages its own subscriptions. When a connection closes, only that connection's subscriptions are cancelled.
+- **Broadcasting targets connections explicitly** — when you use `JsonRPCBroadcaster`, you choose whether to send to all connected clients or to a specific session by ID.
+
+There is no risk of one user seeing another user's responses or interfering with their subscriptions.
+
+== Shared Bean Instances
+
+While connections are isolated, the `@JsonRPCApi` beans that handle requests are **shared across all connections**. Classes annotated with `@JsonRPCApi` are registered as `@ApplicationScoped` CDI beans, meaning a single instance serves all users.
+
+This is perfectly fine for stateless services:
+
+[source,java]
+----
+@JsonRPCApi
+public class GreetingService {
+
+    @Inject
+    GreetingRepository repository;
+
+    // Safe — no mutable instance state
+    public String hello(String name) {
+        return repository.greet(name);
+    }
+}
+----
+
+If you need per-user state, do not store it in instance fields. Instead, use a `ConcurrentHashMap` keyed by a user or session identifier, or use a request-scoped CDI bean:
+
+[source,java]
+----
+@JsonRPCApi
+public class StatefulService {
+
+    private final ConcurrentMap<String, UserState> stateByUser = new ConcurrentHashMap<>();
+
+    public String getState(String userId) {
+        return stateByUser.getOrDefault(userId, UserState.EMPTY).toString();
+    }
+}
+----
+
+== Threading Model
+
+The extension runs on the Vert.x event loop and dispatches method calls based on their return type and annotations:
+
+[cols="2,3"]
+|===
+| Scenario | Thread
+
+| Plain return type (default)
+| Worker thread — does **not** block the event loop
+
+| Plain return type + `@NonBlocking`
+| Event loop — must return quickly
+
+| `Uni<T>` / `CompletionStage<T>` (default)
+| Event loop — non-blocking, ideal for reactive I/O
+
+| `Uni<T>` + `@Blocking`
+| Worker thread — wrapped in `vertx.executeBlocking()`
+
+| `Multi<T>` / `Flow.Publisher<T>`
+| Event loop — reactive streaming
+|===
+
+Because blocking calls are offloaded to a worker pool and async calls stay on the event loop, the server can handle many concurrent connections without threads becoming a bottleneck. See xref:guides-execution-modes.adoc[Execution Modes & Return Types] for full details.
+
+== Tuning for Production
+
+The default thread pool sizes work well for development and moderate loads. For production workloads, you can tune them via configuration:
+
+[cols="3,1,3"]
+|===
+| Property | Default | Purpose
+
+| `quarkus.vertx.event-loops-pool-size`
+| 2 × CPU cores
+| Number of event loop threads handling WebSocket I/O and non-blocking methods
+
+| `quarkus.vertx.worker-pool-size`
+| 20
+| Number of worker threads for blocking method calls
+|===
+
+If most of your methods are blocking (plain return types without `@NonBlocking`), consider increasing the worker pool size. If most are reactive (`Uni<T>`, `Multi<T>`), the defaults are usually sufficient even under heavy load.
+
+== Best Practices
+
+* **Prefer `Uni<T>` return types** for I/O-bound methods — this keeps the event loop free and maximizes throughput.
+* **Use `@Blocking` only when necessary** — for example, when calling JDBC or other inherently blocking APIs.
+* **Keep `@JsonRPCApi` beans stateless** — since a single instance serves all connections, avoid mutable instance state or protect it with proper synchronization.
+* **Use `Multi<T>` for server-push scenarios** — it streams items reactively without dedicating a thread per subscription.

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -62,7 +62,7 @@ The following rules apply when the extension scans your class:
 
 == CDI Integration
 
-All `@JsonRPCApi` classes are automatically registered as `@ApplicationScoped` CDI beans. You can inject any CDI bean:
+All `@JsonRPCApi` classes are automatically registered as `@Singleton` CDI beans. You can inject any CDI bean:
 
 [source,java]
 ----
@@ -138,4 +138,6 @@ Standard JSON-RPC 2.0 error codes are used:
 | -32601 | Method not found
 | -32602 | Invalid params
 | -32603 | Internal error
+| -32000 | Unauthorized (authentication required)
+| -32001 | Forbidden (insufficient permissions)
 |===

--- a/docs/modules/ROOT/pages/guides-security.adoc
+++ b/docs/modules/ROOT/pages/guides-security.adoc
@@ -1,0 +1,187 @@
+= Security
+:description: Securing JSON-RPC endpoints with Quarkus security annotations and HTTP policies.
+
+include::./includes/attributes.adoc[]
+
+Quarkus JSON-RPC integrates with the standard Quarkus security framework. You can secure your endpoints using CDI security annotations on your `@JsonRPCApi` classes, or by applying HTTP auth policies to the WebSocket path via configuration. Both approaches are opt-in — endpoints are unsecured by default.
+
+== Security Annotations
+
+Add standard Jakarta security annotations directly to your `@JsonRPCApi` classes and methods. This requires a Quarkus security extension on the classpath (e.g., `quarkus-oidc`, `quarkus-elytron-security-properties-file`).
+
+=== Class-Level Security
+
+Annotations on the class apply to all methods:
+
+[source,java]
+----
+@JsonRPCApi
+@RolesAllowed("admin")
+public class AdminService {
+
+    public String getSecretData() {
+        return "top-secret"; // <1>
+    }
+}
+----
+<1> Only users with the `admin` role can call this method.
+
+=== Method-Level Overrides
+
+Method-level annotations override the class-level setting:
+
+[source,java]
+----
+@JsonRPCApi
+@RolesAllowed("admin")
+public class AdminService {
+
+    public String adminOnly() {
+        return "admin-secret"; // <1>
+    }
+
+    @PermitAll
+    public String publicInfo() {
+        return "public-info"; // <2>
+    }
+
+    @RolesAllowed("user")
+    public String userInfo() {
+        return "user-info"; // <3>
+    }
+}
+----
+<1> Inherits `@RolesAllowed("admin")` from the class.
+<2> `@PermitAll` overrides — any authenticated user can call this.
+<3> `@RolesAllowed("user")` overrides — only users with the `user` role.
+
+=== Supported Annotations
+
+[cols="1,2"]
+|===
+| Annotation | Effect
+
+| `@RolesAllowed("role")`
+| Only users with the specified role(s) can invoke the method.
+
+| `@Authenticated`
+| Any authenticated user can invoke the method.
+
+| `@PermitAll`
+| Any user (including anonymous, if the connection is allowed) can invoke the method.
+
+| `@DenyAll`
+| No user can invoke the method.
+|===
+
+=== Error Responses
+
+When a security check fails, the extension returns a JSON-RPC error response:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32001,
+    "message": "Method [AdminService#adminOnly] failed: ..."
+  }
+}
+----
+
+[cols="1,1,2"]
+|===
+| Code | Name | Meaning
+
+| `-32000`
+| Unauthorized
+| Authentication is required but was not provided or is invalid.
+
+| `-32001`
+| Forbidden
+| Authenticated but not authorized for the requested method.
+|===
+
+== HTTP Auth Policies
+
+You can also secure the entire WebSocket endpoint at the HTTP level using standard Quarkus HTTP auth policies. This protects the WebSocket upgrade — unauthenticated users receive an HTTP 401 response before a WebSocket connection is established.
+
+[source,properties]
+----
+# Require authentication for the JSON-RPC endpoint
+quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc
+quarkus.http.auth.permission.json-rpc.policy=authenticated
+----
+
+This approach works with any Quarkus security mechanism (Basic auth, OIDC, JWT, etc.) and requires no code changes to your `@JsonRPCApi` classes.
+
+=== Role-Based HTTP Policies
+
+You can restrict access to specific roles at the HTTP level:
+
+[source,properties]
+----
+quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc
+quarkus.http.auth.permission.json-rpc.policy=role-policy
+
+quarkus.http.auth.policy.role-policy.roles-allowed=admin,operator
+----
+
+== Combining Both Approaches
+
+Annotations and HTTP policies can be combined:
+
+* *HTTP auth policy* — gates who can _connect_ to the WebSocket.
+* *Security annotations* — gates who can _invoke specific methods_ within a connection.
+
+For example, require authentication to connect, then use `@RolesAllowed` to restrict individual operations:
+
+[source,properties]
+----
+quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc
+quarkus.http.auth.permission.json-rpc.policy=authenticated
+----
+
+[source,java]
+----
+@JsonRPCApi
+public class DataService {
+
+    @RolesAllowed("admin")
+    public String sensitiveOperation() { ... }
+
+    public String regularOperation() { ... } // <1>
+}
+----
+<1> Any authenticated user can call this (connection already requires authentication).
+
+== Example: Basic Auth Setup
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-elytron-security-properties-file</artifactId>
+</dependency>
+----
+
+.application.properties
+[source,properties]
+----
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.admin=secret
+quarkus.security.users.embedded.roles.admin=admin
+----
+
+Connect with credentials:
+
+[source,javascript]
+----
+// Browser WebSocket API does not support Authorization headers directly.
+// Use a server-side proxy or the Quarkus Sec-WebSocket-Protocol pattern
+// for browser-based clients. Java/Node.js clients can set headers directly.
+----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -106,6 +106,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 | xref:guides-security.adoc[Security]
 | Secure endpoints with annotations or HTTP auth policies.
 
+| xref:guides-concurrency.adoc[Concurrency & Session Isolation]
+| Connection isolation, shared bean instances, threading model, and tuning for production.
+
 | xref:guides-javascript-client.adoc[JavaScript Client]
 | Generate a typed JavaScript proxy for calling your endpoints from the browser.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -73,6 +73,9 @@ Call methods with named parameters (JSON object) or positional parameters (JSON 
 POJO support::
 Complex types are serialized and deserialized automatically via Jackson, including nested objects, collections, and Java time types.
 
+Security::
+Secure your endpoints with standard Jakarta security annotations (`@RolesAllowed`, `@Authenticated`, etc.) or Quarkus HTTP auth policies — opt-in, no changes needed for unsecured use cases.
+
 JavaScript client::
 Optionally generate a typed JavaScript proxy for all your endpoints, ready to import from Quarkus Web Bundler or any ES module environment.
 
@@ -99,6 +102,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 
 | xref:guides-broadcasting.adoc[Broadcasting]
 | Push notifications to clients from any CDI bean.
+
+| xref:guides-security.adoc[Security]
+| Secure endpoints with annotations or HTTP auth policies.
 
 | xref:guides-javascript-client.adoc[JavaScript Client]
 | Generate a typed JavaScript proxy for calling your endpoints from the browser.

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -24,6 +24,8 @@ import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCRequest;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.context.SmallRyeThreadContext;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -45,6 +47,8 @@ public class JsonRPCRouter {
     private final JsonRPCCodec codec;
 
     private final Map<ServerWebSocket, Map<String, Cancellable>> socketSubscriptions = new ConcurrentHashMap<>();
+
+    private final Map<ServerWebSocket, SecurityIdentity> socketIdentities = new ConcurrentHashMap<>();
 
     // Map json-rpc method to java in runtime classpath
     private final Map<String, ReflectionInfo> jsonRpcToJava = new HashMap<>();
@@ -95,8 +99,25 @@ public class JsonRPCRouter {
         }
     }
 
+    /**
+     * Set the security identity captured during WebSocket upgrade into the current request context,
+     * so CDI security interceptors ({@code @RolesAllowed}, {@code @Authenticated}, etc.) can authorize
+     * method invocations.
+     */
+    private void setSecurityIdentity(ServerWebSocket socket) {
+        SecurityIdentity identity = socketIdentities.get(socket);
+        if (identity != null) {
+            try {
+                CurrentIdentityAssociation cia = Arc.container().select(CurrentIdentityAssociation.class).get();
+                cia.setIdentity(identity);
+            } catch (Exception e) {
+                LOG.debugf("Could not set security identity: %s", e.getMessage());
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
-    private Uni<?> invoke(ReflectionInfo info, Object target, Object[] args) {
+    private Uni<?> invoke(ReflectionInfo info, Object target, Object[] args, ServerWebSocket socket) {
         Context vc = Vertx.currentContext();
 
         ManagedContext currentManagedContext = Arc.container().requestContext();
@@ -106,6 +127,7 @@ public class JsonRPCRouter {
                 currentManagedContext.activate();
                 activated = true;
             }
+            setSecurityIdentity(socket);
             if (info.isReturningUni()) {
                 if (info.isExplicitlyBlocking()) {
                     SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
@@ -167,13 +189,21 @@ public class JsonRPCRouter {
     }
 
     public void addSocket(ServerWebSocket socket) {
+        addSocket(socket, null);
+    }
+
+    public void addSocket(ServerWebSocket socket, SecurityIdentity identity) {
         sessions.addSession(socket);
+        if (identity != null && !identity.isAnonymous()) {
+            socketIdentities.put(socket, identity);
+        }
         socket.textMessageHandler((e) -> {
             JsonRPCRequest jsonRpcRequest = codec.readRequest(e);
             route(jsonRpcRequest, socket);
         });
         socket.closeHandler((e) -> {
             sessions.removeSession(socket);
+            socketIdentities.remove(socket);
             Map<String, Cancellable> subs = socketSubscriptions.remove(socket);
             if (subs != null) {
                 for (Map.Entry<String, Cancellable> entry : subs.entrySet()) {
@@ -209,7 +239,15 @@ public class JsonRPCRouter {
 
             if (reflectionInfo.isReturningMulti() || reflectionInfo.isReturningFlowPublisher()) {
                 Multi<?> multi;
+                ManagedContext requestContext = Arc.container().requestContext();
+                boolean activated = false;
                 try {
+                    if (!requestContext.isActive()) {
+                        requestContext.activate();
+                        activated = true;
+                    }
+                    setSecurityIdentity(s);
+
                     Object result;
                     if (jsonRpcRequest.hasParams()) {
                         Object[] args = getArgsAsObjects(reflectionInfo, jsonRpcRequest);
@@ -227,6 +265,10 @@ public class JsonRPCRouter {
                             jsonRpcRequest);
                     codec.writeErrorResponse(s, jsonRpcRequest.getId(), jsonRpcRequest.getMethod(), unwrap(e));
                     return;
+                } finally {
+                    if (activated) {
+                        requestContext.deactivate();
+                    }
                 }
 
                 String subscriptionId = UUID.randomUUID().toString();
@@ -262,9 +304,9 @@ public class JsonRPCRouter {
                 try {
                     if (jsonRpcRequest.hasParams()) {
                         Object[] args = getArgsAsObjects(reflectionInfo, jsonRpcRequest);
-                        uni = invoke(reflectionInfo, target, args);
+                        uni = invoke(reflectionInfo, target, args, s);
                     } else {
-                        uni = invoke(reflectionInfo, target, new Object[0]);
+                        uni = invoke(reflectionInfo, target, new Object[0], s);
                     }
                 } catch (Exception e) {
                     LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", jsonRpcRequest.getMethod(),

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -50,6 +50,9 @@ public class JsonRPCRouter {
 
     private final Map<ServerWebSocket, SecurityIdentity> socketIdentities = new ConcurrentHashMap<>();
 
+    private volatile CurrentIdentityAssociation identityAssociation;
+    private volatile boolean identityAssociationUnavailable;
+
     // Map json-rpc method to java in runtime classpath
     private final Map<String, ReflectionInfo> jsonRpcToJava = new HashMap<>();
 
@@ -107,13 +110,29 @@ public class JsonRPCRouter {
     private void setSecurityIdentity(ServerWebSocket socket) {
         SecurityIdentity identity = socketIdentities.get(socket);
         if (identity != null) {
-            try {
-                CurrentIdentityAssociation cia = Arc.container().select(CurrentIdentityAssociation.class).get();
+            CurrentIdentityAssociation cia = getIdentityAssociation();
+            if (cia != null) {
                 cia.setIdentity(identity);
-            } catch (Exception e) {
-                LOG.debugf("Could not set security identity: %s", e.getMessage());
             }
         }
+    }
+
+    private CurrentIdentityAssociation getIdentityAssociation() {
+        if (identityAssociationUnavailable) {
+            return null;
+        }
+        CurrentIdentityAssociation result = identityAssociation;
+        if (result == null) {
+            try {
+                result = Arc.container().select(CurrentIdentityAssociation.class).get();
+                identityAssociation = result;
+            } catch (jakarta.enterprise.inject.UnsatisfiedResolutionException e) {
+                LOG.debugf("CurrentIdentityAssociation not available — no security extension present");
+                identityAssociationUnavailable = true;
+                return null;
+            }
+        }
+        return result;
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCWebSocket.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCWebSocket.java
@@ -2,6 +2,8 @@ package io.quarkiverse.jsonrpc.runtime;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.http.ServerWebSocket;
@@ -22,12 +24,20 @@ public class JsonRPCWebSocket implements Handler<RoutingContext> {
     @Override
     public void handle(RoutingContext event) {
         if (WEBSOCKET.equalsIgnoreCase(event.request().getHeader(UPGRADE)) && !event.request().isEnded()) {
+            // Capture security identity before WebSocket upgrade so it can be
+            // associated with the socket and used for method-level authorization.
+            SecurityIdentity identity = null;
+            if (event.user() instanceof QuarkusHttpUser httpUser) {
+                identity = httpUser.getSecurityIdentity();
+            }
+
+            final SecurityIdentity capturedIdentity = identity;
             event.request().toWebSocket(new Handler<AsyncResult<ServerWebSocket>>() {
                 @Override
                 public void handle(AsyncResult<ServerWebSocket> event) {
                     if (event.succeeded()) {
                         ServerWebSocket socket = event.result();
-                        addSocket(socket);
+                        jsonRpcRouter.addSocket(socket, capturedIdentity);
                     } else {
                         LOG.error("Failed to connect to json-rpc websocket server", event.cause());
                     }
@@ -36,10 +46,6 @@ public class JsonRPCWebSocket implements Handler<RoutingContext> {
             return;
         }
         event.next();
-    }
-
-    private void addSocket(ServerWebSocket session) {
-        jsonRpcRouter.addSocket(session);
     }
 
     private static final String UPGRADE = "Upgrade";

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -40,7 +40,18 @@ public class JsonRPCCodec {
     }
 
     public void writeErrorResponse(ServerWebSocket socket, int id, String jsonRpcMethodName, Throwable exception) {
-        writeErrorResponse(socket, id, JsonRPCKeys.INTERNAL_ERROR, jsonRpcMethodName, exception);
+        int code = resolveErrorCode(exception);
+        writeErrorResponse(socket, id, code, jsonRpcMethodName, exception);
+    }
+
+    private int resolveErrorCode(Throwable exception) {
+        if (exception instanceof io.quarkus.security.UnauthorizedException) {
+            return JsonRPCKeys.UNAUTHORIZED;
+        }
+        if (exception instanceof io.quarkus.security.ForbiddenException) {
+            return JsonRPCKeys.FORBIDDEN;
+        }
+        return JsonRPCKeys.INTERNAL_ERROR;
     }
 
     public void writeErrorResponse(ServerWebSocket socket, int id, int code, String jsonRpcMethodName,

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCKeys.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCKeys.java
@@ -21,4 +21,8 @@ public interface JsonRPCKeys {
     public static final int METHOD_NOT_FOUND = -32601; // Method not found. The method does not exist / is not available.
     public static final int INVALID_PARAMS = -32602; // Invalid params.	Invalid method parameter(s).
     public static final int INTERNAL_ERROR = -32603; //	Internal error. Internal JSON-RPC error.
+
+    // Server-defined errors (JSON-RPC 2.0 reserved range: -32000 to -32099)
+    public static final int UNAUTHORIZED = -32000; // Unauthorized. Authentication is required but was not provided or is invalid.
+    public static final int FORBIDDEN = -32001; // Forbidden. Authenticated but not authorized for the requested method.
 }

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -35,6 +35,10 @@
             <version>3.3.2</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/SecuredResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/SecuredResource.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.jsonrpc.sample;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+/**
+ * Demonstrates security annotations on a JSON-RPC API.
+ * <p>
+ * Class-level {@code @RolesAllowed("admin")} requires the "admin" role by default.
+ * Individual methods can override with {@code @PermitAll} or a different {@code @RolesAllowed}.
+ */
+@JsonRPCApi
+@RolesAllowed("admin")
+public class SecuredResource {
+
+    /**
+     * Only users with the "admin" role can call this.
+     */
+    public String adminSecret() {
+        return "Top-secret admin data";
+    }
+
+    /**
+     * Only users with the "admin" role can call this.
+     */
+    public String adminGreeting(String name) {
+        return "Hello " + name + ", welcome to the admin area";
+    }
+
+    /**
+     * Any authenticated user can call this (overrides class-level restriction).
+     */
+    @PermitAll
+    public String publicInfo() {
+        return "This information is available to everyone";
+    }
+
+    /**
+     * Only users with the "user" role can call this (overrides class-level restriction).
+     */
+    @RolesAllowed("user")
+    public String userDashboard() {
+        return "Welcome to the user dashboard";
+    }
+}

--- a/sample/src/main/resources/application.properties
+++ b/sample/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 quarkus.json-rpc.client.enabled=true
+
+# Security: Basic auth with embedded users
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.admin=admin
+quarkus.security.users.embedded.roles.admin=admin
+quarkus.security.users.embedded.users.user=user
+quarkus.security.users.embedded.roles.user=user

--- a/sample/src/main/resources/web/app/jsonrpc-app.js
+++ b/sample/src/main/resources/web/app/jsonrpc-app.js
@@ -334,7 +334,7 @@ class JsonRpcApp extends LitElement {
             return html`<h1>Loading...</h1>`;
         }
 
-        const {HelloResource, PojoResource, scoped} = this._rpc;
+        const {HelloResource, PojoResource, SecuredResource, scoped} = this._rpc;
 
         const calls = [
             ['HelloResource.hello()', () => HelloResource.hello()],
@@ -349,6 +349,13 @@ class JsonRpcApp extends LitElement {
             ['scoped.hello()', () => scoped.hello()],
             ['scoped.hello({name})', () => scoped.hello({name: 'World'})],
             ['scoped.pojo()', () => scoped.pojo()],
+        ];
+
+        const securedCalls = [
+            ['adminSecret() @RolesAllowed("admin")', () => SecuredResource.adminSecret()],
+            ['adminGreeting({name}) @RolesAllowed("admin")', () => SecuredResource.adminGreeting({name: 'Boss'})],
+            ['publicInfo() @PermitAll', () => SecuredResource.publicInfo()],
+            ['userDashboard() @RolesAllowed("user")', () => SecuredResource.userDashboard()],
         ];
 
         const streams = [
@@ -370,6 +377,15 @@ class JsonRpcApp extends LitElement {
                     <label>Click a method to invoke it</label>
                     <div class="quick-methods">
                         ${calls.map(([label, fn]) =>
+                            html`<button ?disabled=${!this._connected}
+                                         @click=${() => this._call(label, fn)}>${label}</button>`
+                        )}
+                    </div>
+
+                    <h2>Secured Methods</h2>
+                    <label>Methods with security annotations (connect as admin:admin or user:user)</label>
+                    <div class="quick-methods">
+                        ${securedCalls.map(([label, fn]) =>
                             html`<button ?disabled=${!this._connected}
                                          @click=${() => this._call(label, fn)}>${label}</button>`
                         )}


### PR DESCRIPTION
## Summary

- Add support for standard Jakarta security annotations (`@RolesAllowed`, `@Authenticated`, `@PermitAll`, `@DenyAll`) on `@JsonRPCApi` classes and methods
- Capture `SecurityIdentity` during WebSocket upgrade and propagate it to `CurrentIdentityAssociation` before each method invocation, enabling CDI security interceptors
- Map `ForbiddenException` and `UnauthorizedException` to JSON-RPC error codes `-32001` and `-32000` respectively
- Verify that standard Quarkus HTTP auth policies (`quarkus.http.auth.permission.*`) work for securing the WebSocket upgrade path

Security is fully opt-in — existing endpoints remain unsecured by default. Users can secure at two levels:

1. **HTTP auth policies** — gates who can _connect_ (rejects upgrade with 401/403)
2. **Security annotations** — gates who can _invoke specific methods_ within a connection (returns JSON-RPC error response)

Both approaches can be combined, and method-level annotations override class-level ones.

Closes #77