### PR TITLE
ci: migrate to shared quarkiverse release workflows

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -23,7 +23,7 @@ jobs:
     name: pre release
 
     steps:
-      - uses: radcortez/project-metadata-action@master
+      - uses: radcortez/project-metadata-action@main
         name: retrieve project metadata
         id: metadata
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,9 @@ jobs:
         run: |
           git push
           git push origin ${{steps.metadata.outputs.current-version}}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{steps.metadata.outputs.current-version}}
+          generate_release_notes: true


### PR DESCRIPTION
The `quarkiverse-parent` v20 migrated from the old OSSRH/Nexus Staging approach to a centralized release process, removing `distributionManagement` and the `nexus-staging-maven-plugin` from the parent POM. This broke our release because `mvn release:perform` could no longer find a deployment repository.

This PR replaces the old monolithic `release.yml` with the new two-phase approach using reusable workflows from `quarkiverse/.github`:

- **`release-prepare.yml`** — triggered when a `.github/project.yml` PR is merged. Runs `mvn release:prepare`, pushes the tag, and creates a GitHub Release with auto-generated notes.
- **`release-perform.yml`** — triggered by the tag push. Deploys artifacts to a local file repository, generates build attestations, and hands them off to `quarkiverse/quarkiverse-release` for publishing to Maven Central.
- **`pre-release.yml`** — simplified to delegate to the shared reusable workflow.