### PR TITLE
feat(security): add JS client authentication via Sec-WebSocket-Protocol

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -256,9 +256,11 @@ public class JsonRPCProcessor {
     void registerSubProtocolFilter(
             JsonRPCConfig jsonRPCConfig,
             JsonRPCRecorder recorder,
+            HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<FilterBuildItem> filterProducer) {
         if (jsonRPCConfig.webSocket().enabled()) {
-            filterProducer.produce(new FilterBuildItem(recorder.subProtocolHandler(), 300));
+            String resolvedPath = httpRootPathBuildItem.resolvePath(jsonRPCConfig.webSocket().path());
+            filterProducer.produce(new FilterBuildItem(recorder.subProtocolHandler(resolvedPath), 300));
         }
     }
 

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -57,6 +57,7 @@ import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
@@ -247,6 +248,17 @@ public class JsonRPCProcessor {
                             .routeConfigKey("quarkus.json-rpc.web-socket.path")
                             .handler(recorder.webSocketHandler(beanContainerBuildItem.getValue()))
                             .build());
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void registerSubProtocolFilter(
+            JsonRPCConfig jsonRPCConfig,
+            JsonRPCRecorder recorder,
+            BuildProducer<FilterBuildItem> filterProducer) {
+        if (jsonRPCConfig.webSocket().enabled()) {
+            filterProducer.produce(new FilterBuildItem(recorder.subProtocolHandler(), 300));
         }
     }
 

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -6,6 +6,19 @@
  */
 
 export class JsonRPCClient {
+    static _config = {};
+
+    /**
+     * Set global defaults for all JsonRPCClient instances.
+     *
+     * @param {Object} options - Configuration options
+     * @param {string} [options.token] - Static bearer token
+     * @param {Function} [options.tokenProvider] - Callback returning a token string
+     */
+    static configure(options = {}) {
+        JsonRPCClient._config = { ...JsonRPCClient._config, ...options };
+    }
+
     _ws = null;
     _url = null;
     _path;
@@ -19,23 +32,28 @@ export class JsonRPCClient {
     _reconnectTimer = null;
     _manuallyDisconnected = false;
     _connected = false;
+    _token = null;
+    _tokenProvider = null;
 
     onOpen = null;
     onClose = null;
     onError = null;
 
     constructor(options = {}) {
-        this._path = options.path || '/quarkus/json-rpc';
-        this._url = options.url || null;
-        this._autoReconnect = options.autoReconnect !== false;
+        const merged = { ...JsonRPCClient._config, ...options };
+        this._path = merged.path || '/quarkus/json-rpc';
+        this._url = merged.url || null;
+        this._autoReconnect = merged.autoReconnect !== false;
         this._reconnectDelay = 1000;
-        this._maxReconnectDelay = options.maxReconnectDelay || 30000;
+        this._maxReconnectDelay = merged.maxReconnectDelay || 30000;
+        this._token = merged.token || null;
+        this._tokenProvider = merged.tokenProvider || null;
 
-        if (options.onOpen) this.onOpen = options.onOpen;
-        if (options.onClose) this.onClose = options.onClose;
-        if (options.onError) this.onError = options.onError;
+        if (merged.onOpen) this.onOpen = merged.onOpen;
+        if (merged.onClose) this.onClose = merged.onClose;
+        if (merged.onError) this.onError = merged.onError;
 
-        if (options.autoConnect !== false) {
+        if (merged.autoConnect !== false) {
             this.connect();
         }
     }
@@ -72,6 +90,28 @@ export class JsonRPCClient {
         return this._connected;
     }
 
+    get token() {
+        return this._token;
+    }
+
+    set token(value) {
+        this._token = value;
+    }
+
+    /**
+     * Update the authentication token and reconnect.
+     *
+     * @param {string} newToken - The new bearer token
+     */
+    updateToken(newToken) {
+        this._token = newToken;
+        if (this._ws) {
+            this.disconnect();
+            this._manuallyDisconnected = false;
+            this.connect();
+        }
+    }
+
     connect() {
         this._manuallyDisconnected = false;
         if (this._ws) return;
@@ -80,7 +120,10 @@ export class JsonRPCClient {
             this._reconnectTimer = null;
         }
 
-        const ws = new WebSocket(this.url);
+        const protocols = this._buildProtocols();
+        const ws = protocols.length > 0
+            ? new WebSocket(this.url, protocols)
+            : new WebSocket(this.url);
         this._ws = ws;
 
         ws.onopen = () => {
@@ -218,6 +261,22 @@ export class JsonRPCClient {
             this._subscriptions.delete(subscriptionId);
             return result;
         });
+    }
+
+    _resolveToken() {
+        if (this._tokenProvider) {
+            return this._tokenProvider();
+        }
+        return this._token;
+    }
+
+    _buildProtocols() {
+        const token = this._resolveToken();
+        if (!token) return [];
+        const encoded = encodeURIComponent(
+            'quarkus-http-upgrade#Authorization#' + token
+        );
+        return ['bearer-token-carrier', encoded];
     }
 
     _send(message) {

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -13,7 +13,7 @@ export class JsonRPCClient {
      *
      * @param {Object} options - Configuration options
      * @param {string} [options.token] - Static bearer token
-     * @param {Function} [options.tokenProvider] - Callback returning a token string
+     * @param {Function} [options.tokenProvider] - Callback returning a token string (sync or async)
      */
     static configure(options = {}) {
         JsonRPCClient._config = { ...JsonRPCClient._config, ...options };
@@ -120,7 +120,14 @@ export class JsonRPCClient {
             this._reconnectTimer = null;
         }
 
-        const protocols = this._buildProtocols();
+        Promise.resolve(this._resolveToken()).then(token => {
+            if (this._manuallyDisconnected || this._ws) return;
+            this._openSocket(token);
+        });
+    }
+
+    _openSocket(token) {
+        const protocols = this._buildProtocols(token);
         const ws = protocols.length > 0
             ? new WebSocket(this.url, protocols)
             : new WebSocket(this.url);
@@ -270,8 +277,7 @@ export class JsonRPCClient {
         return this._token;
     }
 
-    _buildProtocols() {
-        const token = this._resolveToken();
+    _buildProtocols(token) {
         if (!token) return [];
         const encoded = encodeURIComponent(
             'quarkus-http-upgrade#Authorization#' + token

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecuritySubProtocolJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecuritySubProtocolJsonRpcTest.java
@@ -1,0 +1,182 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.SecuredResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests authentication via the {@code Sec-WebSocket-Protocol} header encoding pattern.
+ * <p>
+ * Uses the same {@link SecuredResource} and embedded users as {@link SecurityJsonRpcTest},
+ * but encodes credentials in the sub-protocol header instead of the {@code Authorization} header.
+ */
+public class SecuritySubProtocolJsonRpcTest {
+
+    private final AtomicInteger count = new AtomicInteger(0);
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(SecuredResource.class);
+                root.addAsResource(new org.jboss.shrinkwrap.api.asset.StringAsset(
+                        "quarkus.http.auth.basic=true\n" +
+                                "quarkus.security.users.embedded.enabled=true\n" +
+                                "quarkus.security.users.embedded.plain-text=true\n" +
+                                "quarkus.security.users.embedded.users.admin=admin\n" +
+                                "quarkus.security.users.embedded.roles.admin=admin\n" +
+                                "quarkus.security.users.embedded.users.user=user\n" +
+                                "quarkus.security.users.embedded.roles.user=user\n"),
+                        "application.properties");
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("quarkus/json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testAdminCanAccessViaSubProtocol() throws Exception {
+        String result = callWithSubProtocolAuth("SecuredResource#adminOnly", "admin", "admin");
+        Assertions.assertEquals("admin-secret", result);
+    }
+
+    @Test
+    public void testUserForbiddenViaSubProtocol() throws Exception {
+        JsonObject response = callWithSubProtocolAuthRaw("SecuredResource#adminOnly", "user", "user");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for unauthorized user");
+        int code = response.getJsonObject("error").getInteger("code");
+        Assertions.assertEquals(-32001, code, "Expected FORBIDDEN error code");
+    }
+
+    @Test
+    public void testAnonymousCannotAccessAdminViaSubProtocol() throws Exception {
+        JsonObject response = callAnonymousRaw("SecuredResource#adminOnly");
+        Assertions.assertNotNull(response.getJsonObject("error"), "Expected error response for anonymous user");
+        int code = response.getJsonObject("error").getInteger("code");
+        Assertions.assertTrue(code == -32000 || code == -32001,
+                "Expected UNAUTHORIZED or FORBIDDEN error code, got: " + code);
+    }
+
+    @Test
+    public void testAdminCanAccessPermitAllViaSubProtocol() throws Exception {
+        String result = callWithSubProtocolAuth("SecuredResource#publicInfo", "admin", "admin");
+        Assertions.assertEquals("public-info", result);
+    }
+
+    @Test
+    public void testUserCanAccessPermitAllViaSubProtocol() throws Exception {
+        String result = callWithSubProtocolAuth("SecuredResource#publicInfo", "user", "user");
+        Assertions.assertEquals("public-info", result);
+    }
+
+    // --- Helper methods ---
+
+    private String callWithSubProtocolAuth(String method, String username, String password) throws Exception {
+        JsonObject response = callWithSubProtocolAuthRaw(method, username, password);
+        JsonObject error = response.getJsonObject("error");
+        if (error != null) {
+            Assertions.fail("Unexpected error: " + error.encodePrettily());
+        }
+        return response.getString("result");
+    }
+
+    private JsonObject callWithSubProtocolAuthRaw(String method, String username, String password) throws Exception {
+        int id = count.incrementAndGet();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+
+            String credentials = Base64.getEncoder()
+                    .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String encodedHeader = URLEncoder.encode(
+                    "quarkus-http-upgrade#Authorization#Basic " + credentials,
+                    StandardCharsets.UTF_8);
+
+            // Use addHeader instead of addSubProtocol to match browser behavior.
+            // Browsers send Sec-WebSocket-Protocol as a raw header and accept the
+            // connection even when the server doesn't echo back a subprotocol.
+            // The Vert.x WebSocket client is stricter and would reject in that case.
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setPort(jsonRpcUri.getPort())
+                    .setHost(jsonRpcUri.getHost())
+                    .setURI(jsonRpcUri.getPath())
+                    .addHeader("Sec-WebSocket-Protocol", "bearer-token-carrier, " + encodedHeader);
+
+            client.connect(options)
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            ws.textMessageHandler(msg -> message.add(msg));
+
+                            JsonObject jsonObject = JsonObject.of("jsonrpc", "2.0", "id", id, "method", method);
+                            ws.writeTextMessage(jsonObject.encodePrettily());
+                        } else {
+                            message.add("{\"id\":" + id
+                                    + ",\"error\":{\"code\":-32000,\"message\":\"WebSocket upgrade rejected: "
+                                    + r.cause().getMessage() + "\"}}");
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return Json.decodeValue(response, JsonObject.class);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private JsonObject callAnonymousRaw(String method) throws Exception {
+        int id = count.incrementAndGet();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+
+            WebSocketConnectOptions options = new WebSocketConnectOptions()
+                    .setPort(jsonRpcUri.getPort())
+                    .setHost(jsonRpcUri.getHost())
+                    .setURI(jsonRpcUri.getPath());
+
+            client.connect(options)
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            ws.textMessageHandler(msg -> message.add(msg));
+
+                            JsonObject jsonObject = JsonObject.of("jsonrpc", "2.0", "id", id, "method", method);
+                            ws.writeTextMessage(jsonObject.encodePrettily());
+                        } else {
+                            message.add("{\"id\":" + id
+                                    + ",\"error\":{\"code\":-32000,\"message\":\"WebSocket upgrade rejected: "
+                                    + r.cause().getMessage() + "\"}}");
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return Json.decodeValue(response, JsonObject.class);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/guides-javascript-client.adoc
+++ b/docs/modules/ROOT/pages/guides-javascript-client.adoc
@@ -160,6 +160,32 @@ console.log(client.connected); // true or false
 client.disconnect();
 ----
 
+== Authentication
+
+See the xref:guides-security.adoc#_browser_authentication[Security guide — Browser Authentication] for full details on authenticating from the browser.
+
+=== Global Defaults
+
+Use `JsonRPCClient.configure()` to set defaults for all client instances, including the one created by the generated proxy:
+
+[source,javascript]
+----
+import { JsonRPCClient } from '@quarkiverse/json-rpc';
+
+JsonRPCClient.configure({ token: 'Bearer my-jwt-token' });
+----
+
+=== Per-Instance Auth
+
+Pass `token` or `tokenProvider` in the constructor options. Instance options override global defaults:
+
+[source,javascript]
+----
+const client = new JsonRPCClient({
+    token: 'Basic ' + btoa('admin:secret')
+});
+----
+
 == Constructor Options
 
 [cols="1,1,1,2"]
@@ -190,6 +216,16 @@ client.disconnect();
 | `number`
 | `30000`
 | Maximum reconnect backoff delay in milliseconds
+
+| `token`
+| `string`
+|
+| Auth token sent via `Sec-WebSocket-Protocol` encoding (e.g., `'Bearer my-jwt'` or `'Basic ...'`)
+
+| `tokenProvider`
+| `function`
+|
+| Callback returning a token string (sync or async). Called on each `connect()`
 
 | `onOpen`
 | `function`

--- a/docs/modules/ROOT/pages/guides-security.adoc
+++ b/docs/modules/ROOT/pages/guides-security.adoc
@@ -177,11 +177,65 @@ quarkus.security.users.embedded.users.admin=secret
 quarkus.security.users.embedded.roles.admin=admin
 ----
 
-Connect with credentials:
+Connect with credentials from a Java or Node.js client (which supports custom headers directly):
 
 [source,javascript]
 ----
-// Browser WebSocket API does not support Authorization headers directly.
-// Use a server-side proxy or the Quarkus Sec-WebSocket-Protocol pattern
-// for browser-based clients. Java/Node.js clients can set headers directly.
+// Node.js — custom headers are supported
+const ws = new WebSocket('ws://localhost:8080/quarkus/json-rpc', {
+    headers: { Authorization: 'Basic ' + btoa('admin:secret') }
+});
 ----
+
+== Browser Authentication
+
+JavaScript's browser `WebSocket` API does not support custom headers like `Authorization`. The extension provides built-in support for the Quarkus `Sec-WebSocket-Protocol` encoding pattern, which encodes credentials into the sub-protocol header during the upgrade handshake. The server-side filter extracts these credentials and sets them as real HTTP headers before Quarkus authentication runs.
+
+=== Using the Generated Proxy
+
+The simplest approach — set global auth defaults and the generated proxy picks them up automatically:
+
+[source,javascript]
+----
+import { JsonRPCClient } from '@quarkiverse/json-rpc';
+import { AdminService } from '@quarkiverse/json-rpc-api';
+
+// Static token
+JsonRPCClient.configure({ token: 'Bearer my-jwt-token' });
+
+// Or use a dynamic provider (sync or async)
+JsonRPCClient.configure({
+    tokenProvider: async () => {
+        const token = await fetchAccessToken();
+        return 'Bearer ' + token;
+    }
+});
+
+// Calls are authenticated automatically
+const result = await AdminService.adminOnly();
+----
+
+=== Using the Client Library Directly
+
+[source,javascript]
+----
+import { JsonRPCClient } from '@quarkiverse/json-rpc';
+
+const client = new JsonRPCClient({
+    token: 'Basic ' + btoa('admin:secret')
+});
+
+const result = await client.call('AdminService#adminOnly');
+----
+
+=== Refreshing Tokens
+
+Use `updateToken()` to update the token and reconnect with new credentials:
+
+[source,javascript]
+----
+// Token refresh — disconnects and reconnects automatically
+client.updateToken('Bearer ' + newAccessToken);
+----
+
+Setting the `token` property directly updates the stored token without reconnecting. The new token takes effect on the next connection (e.g., after a reconnect).

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -60,7 +60,7 @@ public class JsonRPCRecorder {
         return new JsonRPCWebSocket(beanContainer.beanInstance(JsonRPCRouter.class));
     }
 
-    public Handler<RoutingContext> subProtocolHandler() {
-        return new JsonRPCSubProtocolHandler();
+    public Handler<RoutingContext> subProtocolHandler(String wsPath) {
+        return new JsonRPCSubProtocolHandler(wsPath);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -59,4 +59,8 @@ public class JsonRPCRecorder {
     public Handler<RoutingContext> webSocketHandler(BeanContainer beanContainer) {
         return new JsonRPCWebSocket(beanContainer.beanInstance(JsonRPCRouter.class));
     }
+
+    public Handler<RoutingContext> subProtocolHandler() {
+        return new JsonRPCSubProtocolHandler();
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSubProtocolHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSubProtocolHandler.java
@@ -4,6 +4,8 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.jboss.logging.Logger;
 
@@ -25,6 +27,10 @@ import io.vertx.ext.web.RoutingContext;
  * request so that Quarkus authentication mechanisms can process them normally.
  * The encoded entries are removed from {@code Sec-WebSocket-Protocol}, leaving
  * only real sub-protocol names.
+ * <p>
+ * Only headers in the {@link #ALLOWED_HEADERS} allowlist are accepted to prevent
+ * arbitrary header injection. The filter is scoped to the configured JSON-RPC
+ * WebSocket path.
  */
 public class JsonRPCSubProtocolHandler implements Handler<RoutingContext> {
     private static final Logger LOG = Logger.getLogger(JsonRPCSubProtocolHandler.class.getName());
@@ -34,8 +40,21 @@ public class JsonRPCSubProtocolHandler implements Handler<RoutingContext> {
     private static final String WEBSOCKET = "websocket";
     private static final String QUARKUS_HTTP_UPGRADE_PREFIX = "quarkus-http-upgrade#";
 
+    private static final Set<String> ALLOWED_HEADERS = Set.of("authorization");
+
+    private final String wsPath;
+
+    public JsonRPCSubProtocolHandler(String wsPath) {
+        this.wsPath = wsPath;
+    }
+
     @Override
     public void handle(RoutingContext event) {
+        if (!event.request().path().equals(wsPath)) {
+            event.next();
+            return;
+        }
+
         if (!WEBSOCKET.equalsIgnoreCase(event.request().getHeader(UPGRADE))) {
             event.next();
             return;
@@ -53,14 +72,17 @@ public class JsonRPCSubProtocolHandler implements Handler<RoutingContext> {
             String decoded = URLDecoder.decode(trimmed, StandardCharsets.UTF_8);
             if (decoded.startsWith(QUARKUS_HTTP_UPGRADE_PREFIX)) {
                 // Format: quarkus-http-upgrade#HeaderName#HeaderValue
-                // Split with limit 3 to preserve '#' characters in the header value
                 String rest = decoded.substring(QUARKUS_HTTP_UPGRADE_PREFIX.length());
                 int hashIdx = rest.indexOf('#');
                 if (hashIdx > 0) {
                     String headerName = rest.substring(0, hashIdx);
-                    String headerValue = rest.substring(hashIdx + 1);
-                    event.request().headers().set(headerName, headerValue);
-                    LOG.debugf("Extracted header from Sec-WebSocket-Protocol: %s", headerName);
+                    if (ALLOWED_HEADERS.contains(headerName.toLowerCase(Locale.ROOT))) {
+                        String headerValue = rest.substring(hashIdx + 1);
+                        event.request().headers().set(headerName, headerValue);
+                        LOG.debugf("Extracted header from Sec-WebSocket-Protocol: %s", headerName);
+                    } else {
+                        LOG.warnf("Rejected disallowed header from Sec-WebSocket-Protocol: %s", headerName);
+                    }
                 }
             } else {
                 realProtocols.add(trimmed);

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSubProtocolHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSubProtocolHandler.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Extracts HTTP headers encoded in the {@code Sec-WebSocket-Protocol} header
+ * using the Quarkus {@code quarkus-http-upgrade} convention.
+ * <p>
+ * JavaScript's {@code WebSocket} API does not support custom headers, so bearer
+ * tokens are encoded into the sub-protocol header during the upgrade handshake:
+ *
+ * <pre>
+ * Sec-WebSocket-Protocol: bearer-token-carrier, quarkus-http-upgrade%23Authorization%23Bearer%20token
+ * </pre>
+ * <p>
+ * This handler decodes those entries and sets them as real HTTP headers on the
+ * request so that Quarkus authentication mechanisms can process them normally.
+ * The encoded entries are removed from {@code Sec-WebSocket-Protocol}, leaving
+ * only real sub-protocol names.
+ */
+public class JsonRPCSubProtocolHandler implements Handler<RoutingContext> {
+    private static final Logger LOG = Logger.getLogger(JsonRPCSubProtocolHandler.class.getName());
+
+    private static final String SEC_WEBSOCKET_PROTOCOL = "Sec-WebSocket-Protocol";
+    private static final String UPGRADE = "Upgrade";
+    private static final String WEBSOCKET = "websocket";
+    private static final String QUARKUS_HTTP_UPGRADE_PREFIX = "quarkus-http-upgrade#";
+
+    @Override
+    public void handle(RoutingContext event) {
+        if (!WEBSOCKET.equalsIgnoreCase(event.request().getHeader(UPGRADE))) {
+            event.next();
+            return;
+        }
+
+        String header = event.request().getHeader(SEC_WEBSOCKET_PROTOCOL);
+        if (header == null || header.isEmpty()) {
+            event.next();
+            return;
+        }
+
+        List<String> realProtocols = new ArrayList<>();
+        for (String raw : header.split(",")) {
+            String trimmed = raw.trim();
+            String decoded = URLDecoder.decode(trimmed, StandardCharsets.UTF_8);
+            if (decoded.startsWith(QUARKUS_HTTP_UPGRADE_PREFIX)) {
+                // Format: quarkus-http-upgrade#HeaderName#HeaderValue
+                // Split with limit 3 to preserve '#' characters in the header value
+                String rest = decoded.substring(QUARKUS_HTTP_UPGRADE_PREFIX.length());
+                int hashIdx = rest.indexOf('#');
+                if (hashIdx > 0) {
+                    String headerName = rest.substring(0, hashIdx);
+                    String headerValue = rest.substring(hashIdx + 1);
+                    event.request().headers().set(headerName, headerValue);
+                    LOG.debugf("Extracted header from Sec-WebSocket-Protocol: %s", headerName);
+                }
+            } else {
+                realProtocols.add(trimmed);
+            }
+        }
+
+        if (realProtocols.isEmpty()) {
+            event.request().headers().remove(SEC_WEBSOCKET_PROTOCOL);
+        } else {
+            event.request().headers().set(SEC_WEBSOCKET_PROTOCOL, String.join(", ", realProtocols));
+        }
+
+        event.next();
+    }
+}


### PR DESCRIPTION
JavaScript's `WebSocket` API does not support custom headers like `Authorization`. This adds the standard Quarkus `Sec-WebSocket-Protocol` encoding pattern so JS clients can authenticate with secured JSON-RPC endpoints.

### Server-side

A pre-auth filter (`JsonRPCSubProtocolHandler`) registered at `FilterBuildItem` priority 300 (before auth at 200) intercepts WebSocket upgrade requests and extracts credentials encoded as `quarkus-http-upgrade#HeaderName#HeaderValue` from the `Sec-WebSocket-Protocol` header. The decoded headers are set on the request so Quarkus authentication mechanisms process them normally.

### Client-side

`JsonRPCClient` gains:
- `JsonRPCClient.configure({ token, tokenProvider })` — global auth defaults
- Per-instance `token` / `tokenProvider` options (merged with global config)
- `updateToken(newToken)` — refresh token by reconnecting
- Automatic `Sec-WebSocket-Protocol` encoding on connect when auth is configured

### Usage

```javascript
// Static token
JsonRPCClient.configure({ token: "Bearer my-jwt-token" });

// Dynamic token provider
JsonRPCClient.configure({ tokenProvider: () => "Bearer " + getLatestToken() });
```

The generated `jsonrpc-api.js` proxy picks up global config automatically — no per-call auth needed.

Closes #85