### PR TITLE
Add @RunOnVirtualThread support for JSON-RPC methods

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -37,6 +37,7 @@ import io.quarkiverse.jsonrpc.runtime.JsonRPCRouter;
 import io.quarkiverse.jsonrpc.runtime.JsonRPCSessions;
 import io.quarkiverse.jsonrpc.runtime.Keys;
 import io.quarkiverse.jsonrpc.runtime.devui.JsonRPCDevUIService;
+import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
@@ -63,6 +64,7 @@ import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
 
 public class JsonRPCProcessor {
     private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(JsonRPCProcessor.class);
@@ -126,6 +128,39 @@ public class JsonRPCProcessor {
                                         "Method " + classInfo.name() + "." + method.name()
                                                 + " cannot be annotated with both @Blocking and @NonBlocking");
                             }
+                            if (method.hasAnnotation(RunOnVirtualThread.class)
+                                    && method.hasAnnotation(NonBlocking.class)) {
+                                throw new IllegalArgumentException(
+                                        "Method " + classInfo.name() + "." + method.name()
+                                                + " cannot be annotated with both @RunOnVirtualThread and @NonBlocking");
+                            }
+                            if (method.hasAnnotation(RunOnVirtualThread.class)) {
+                                String returnTypeName = method.returnType().name().toString();
+                                if (returnTypeName.equals("io.smallrye.mutiny.Multi")
+                                        || returnTypeName.equals("java.util.concurrent.Flow$Publisher")) {
+                                    throw new IllegalArgumentException(
+                                            "Method " + classInfo.name() + "." + method.name()
+                                                    + " cannot use @RunOnVirtualThread with a streaming return type"
+                                                    + " (Multi/Flow.Publisher)");
+                                }
+                            }
+                            if (method.hasAnnotation(RunOnVirtualThread.class)
+                                    && method.hasAnnotation(Blocking.class)) {
+                                LOG.warnf("Method %s.%s is annotated with both @RunOnVirtualThread and @Blocking."
+                                        + " @Blocking is redundant and will be ignored.",
+                                        classInfo.name(), method.name());
+                            }
+
+                            ExecutionMode executionMode;
+                            if (method.hasAnnotation(RunOnVirtualThread.class)) {
+                                executionMode = ExecutionMode.VIRTUAL_THREAD;
+                            } else if (method.hasAnnotation(Blocking.class)) {
+                                executionMode = ExecutionMode.BLOCKING;
+                            } else if (method.hasAnnotation(NonBlocking.class)) {
+                                executionMode = ExecutionMode.NON_BLOCKING;
+                            } else {
+                                executionMode = ExecutionMode.DEFAULT;
+                            }
 
                             String fullName = null;
 
@@ -143,17 +178,13 @@ public class JsonRPCProcessor {
                                 JsonRPCMethodName jsonRpcMethodName = new JsonRPCMethodName(fullName,
                                         Keys.createOrderedParameterKey(scope, method.name(), method.parametersCount()));
                                 JsonRPCMethod jsonRpcMethod = new JsonRPCMethod(clazz, method.name(), params);
-                                jsonRpcMethod.setExplicitlyBlocking(method.hasAnnotation(Blocking.class));
-                                jsonRpcMethod
-                                        .setExplicitlyNonBlocking(method.hasAnnotation(NonBlocking.class));
+                                jsonRpcMethod.setExecutionMode(executionMode);
                                 methodsMap.put(jsonRpcMethodName, jsonRpcMethod);
                             } else {
                                 fullName = Keys.createKey(scope, method.name());
                                 JsonRPCMethodName jsonRpcMethodName = new JsonRPCMethodName(fullName, null);
                                 JsonRPCMethod jsonRpcMethod = new JsonRPCMethod(clazz, method.name(), null);
-                                jsonRpcMethod.setExplicitlyBlocking(method.hasAnnotation(Blocking.class));
-                                jsonRpcMethod
-                                        .setExplicitlyNonBlocking(method.hasAnnotation(NonBlocking.class));
+                                jsonRpcMethod.setExecutionMode(executionMode);
                                 methodsMap.put(jsonRpcMethodName, jsonRpcMethod);
                             }
 
@@ -439,9 +470,11 @@ public class JsonRPCProcessor {
             }
 
             String execMode = "blocking (default)";
-            if (method.getExplicitlyBlocking()) {
+            if (method.getExecutionMode() == ExecutionMode.VIRTUAL_THREAD) {
+                execMode = "virtual thread";
+            } else if (method.getExecutionMode() == ExecutionMode.BLOCKING) {
                 execMode = "blocking";
-            } else if (method.getExplicitlyNonBlocking()) {
+            } else if (method.getExecutionMode() == ExecutionMode.NON_BLOCKING) {
                 execMode = "non-blocking";
             } else if (isReactiveReturnType(method.getClazz(), method.getMethodName())) {
                 execMode = "non-blocking (default)";

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/RunOnVirtualThreadMultiResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/RunOnVirtualThreadMultiResource.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Multi;
+
+@JsonRPCApi
+public class RunOnVirtualThreadMultiResource {
+
+    @RunOnVirtualThread
+    public Multi<String> stream() {
+        return Multi.createFrom().items("a", "b", "c");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/RunOnVirtualThreadNonBlockingResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/RunOnVirtualThreadNonBlockingResource.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@JsonRPCApi
+public class RunOnVirtualThreadNonBlockingResource {
+
+    @RunOnVirtualThread
+    @NonBlocking
+    public String conflict() {
+        return "This should not be reachable";
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/VirtualThreadResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/VirtualThreadResource.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.jsonrpc.app;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Uni;
+
+@JsonRPCApi
+public class VirtualThreadResource {
+
+    @RunOnVirtualThread
+    public String hello() {
+        return "Hello [" + Thread.currentThread().getName() + "]";
+    }
+
+    @RunOnVirtualThread
+    public String hello(String name) {
+        return "Hello " + name + " [" + Thread.currentThread().getName() + "]";
+    }
+
+    @RunOnVirtualThread
+    public Uni<String> helloUni() {
+        return Uni.createFrom().item("Hello [" + Thread.currentThread().getName() + "]");
+    }
+
+    @RunOnVirtualThread
+    public Uni<String> helloUni(String name) {
+        return Uni.createFrom().item("Hello " + name + " [" + Thread.currentThread().getName() + "]");
+    }
+
+    @RunOnVirtualThread
+    public CompletionStage<String> helloCompletionStage() {
+        return CompletableFuture.completedFuture("Hello [" + Thread.currentThread().getName() + "]");
+    }
+
+    @RunOnVirtualThread
+    public CompletionStage<String> helloCompletionStage(String name) {
+        return CompletableFuture.completedFuture("Hello " + name + " [" + Thread.currentThread().getName() + "]");
+    }
+
+    @RunOnVirtualThread
+    @Blocking
+    public String helloBlocking() {
+        return "Hello [" + Thread.currentThread().getName() + "]";
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/RunOnVirtualThreadMultiValidationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/RunOnVirtualThreadMultiValidationTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.RunOnVirtualThreadMultiResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RunOnVirtualThreadMultiValidationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(RunOnVirtualThreadMultiResource.class);
+            })
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof IllegalArgumentException,
+                        "Expected IllegalArgumentException but got: " + t.getClass().getName());
+                Assertions.assertTrue(
+                        t.getMessage().contains("cannot use @RunOnVirtualThread with a streaming return type"),
+                        "Expected message about streaming return type but got: " + t.getMessage());
+            });
+
+    @Test
+    public void testValidationFails() {
+        Assertions.fail("Should not reach here — build should have failed");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/RunOnVirtualThreadNonBlockingValidationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/RunOnVirtualThreadNonBlockingValidationTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.RunOnVirtualThreadNonBlockingResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RunOnVirtualThreadNonBlockingValidationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(RunOnVirtualThreadNonBlockingResource.class);
+            })
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof IllegalArgumentException,
+                        "Expected IllegalArgumentException but got: " + t.getClass().getName());
+                Assertions.assertTrue(
+                        t.getMessage().contains("cannot be annotated with both @RunOnVirtualThread and @NonBlocking"),
+                        "Expected message about conflicting annotations but got: " + t.getMessage());
+            });
+
+    @Test
+    public void testValidationFails() {
+        Assertions.fail("Should not reach here — build should have failed");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/VirtualThreadJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/VirtualThreadJsonRpcTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.VirtualThreadResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class VirtualThreadJsonRpcTest extends JsonRpcParent {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(VirtualThreadResource.class);
+            });
+
+    @Test
+    public void testHelloVirtualThread() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#hello");
+        Assertions.assertTrue(result.startsWith("Hello ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloVirtualThreadWithParam() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#hello", Map.of("name", "Koos"));
+        Assertions.assertTrue(result.startsWith("Hello Koos ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello Koos [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloVirtualThreadWithParamPosition() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#hello", new String[] { "Mienkie" });
+        Assertions.assertTrue(result.startsWith("Hello Mienkie ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello Mienkie [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloUniVirtualThread() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#helloUni");
+        Assertions.assertTrue(result.startsWith("Hello ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloUniVirtualThreadWithParam() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#helloUni", Map.of("name", "Piet"));
+        Assertions.assertTrue(result.startsWith("Hello Piet ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello Piet [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloCompletionStageVirtualThread() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#helloCompletionStage");
+        Assertions.assertTrue(result.startsWith("Hello ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloCompletionStageVirtualThreadWithParam() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#helloCompletionStage", Map.of("name", "Sannie"));
+        Assertions.assertTrue(result.startsWith("Hello Sannie ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello Sannie [quarkus-virtual-thread-"), result);
+        }
+    }
+
+    @Test
+    public void testHelloBlockingVirtualThread() throws Exception {
+        String result = getJsonRpcResponse("VirtualThreadResource#helloBlocking");
+        Assertions.assertTrue(result.startsWith("Hello ["), result);
+        if (Runtime.version().feature() >= 21) {
+            Assertions.assertTrue(result.startsWith("Hello [quarkus-virtual-thread-"), result);
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/guides-concurrency.adoc
+++ b/docs/modules/ROOT/pages/guides-concurrency.adoc
@@ -64,17 +64,23 @@ The extension runs on the Vert.x event loop and dispatches method calls based on
 | Plain return type + `@NonBlocking`
 | Event loop — must return quickly
 
+| Plain return type + `@RunOnVirtualThread`
+| Virtual thread (Java 21+) — lightweight, ideal for blocking I/O at scale
+
 | `Uni<T>` / `CompletionStage<T>` (default)
 | Event loop — non-blocking, ideal for reactive I/O
 
 | `Uni<T>` + `@Blocking`
 | Worker thread — wrapped in `vertx.executeBlocking()`
 
+| `Uni<T>` + `@RunOnVirtualThread`
+| Virtual thread (Java 21+)
+
 | `Multi<T>` / `Flow.Publisher<T>`
 | Event loop — reactive streaming
 |===
 
-Because blocking calls are offloaded to a worker pool and async calls stay on the event loop, the server can handle many concurrent connections without threads becoming a bottleneck. See xref:guides-execution-modes.adoc[Execution Modes & Return Types] for full details.
+Because blocking calls are offloaded to a worker pool (or virtual threads), and async calls stay on the event loop, the server can handle many concurrent connections without threads becoming a bottleneck. See xref:guides-execution-modes.adoc[Execution Modes & Return Types] for full details.
 
 == Tuning for Production
 

--- a/docs/modules/ROOT/pages/guides-execution-modes.adoc
+++ b/docs/modules/ROOT/pages/guides-execution-modes.adoc
@@ -103,6 +103,53 @@ public class MyService {
 
 `Flow.Publisher<T>` is also supported and treated identically to `Multi<T>`.
 
+== Virtual Threads
+
+If your application runs on Java 21+, you can use `@RunOnVirtualThread` to execute methods on virtual threads instead of the platform worker thread pool. This gives you the simple blocking programming model with much better scalability — virtual threads are cheap and plentiful, so you won't exhaust a fixed thread pool under load.
+
+[source,java]
+----
+@JsonRPCApi
+public class MyService {
+
+    // Runs on a virtual thread
+    @RunOnVirtualThread
+    public String fetchData(String id) {
+        return blockingHttpClient.get(id); // blocking I/O is fine here
+    }
+
+    // Also works with Uni
+    @RunOnVirtualThread
+    public Uni<String> fetchDataUni(String id) {
+        return Uni.createFrom().item(blockingHttpClient.get(id));
+    }
+}
+----
+
+To use `@RunOnVirtualThread`, add the `quarkus-virtual-threads` extension to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-virtual-threads</artifactId>
+</dependency>
+----
+
+[cols="2,3"]
+|===
+| Combination | Behavior
+
+| `@RunOnVirtualThread`
+| Executes on a virtual thread
+
+| `@RunOnVirtualThread` + `@Blocking`
+| Executes on a virtual thread (`@RunOnVirtualThread` takes precedence)
+
+| `@RunOnVirtualThread` + `@NonBlocking`
+| **Build error** — these are contradictory
+|===
+
 == Summary
 
 [cols="3,2,2"]
@@ -111,15 +158,15 @@ public class MyService {
 
 | Plain type
 | Blocking
-| `@NonBlocking`
+| `@NonBlocking`, `@RunOnVirtualThread`
 
 | `Uni<T>`
 | Non-blocking
-| `@Blocking`
+| `@Blocking`, `@RunOnVirtualThread`
 
 | `CompletionStage<T>`
 | Non-blocking
-| `@Blocking`
+| `@Blocking`, `@RunOnVirtualThread`
 
 | `Multi<T>`
 | Non-blocking
@@ -130,4 +177,4 @@ public class MyService {
 | —
 |===
 
-NOTE: A method cannot be annotated with both `@Blocking` and `@NonBlocking`. The build will fail if both are present.
+NOTE: A method cannot be annotated with both `@Blocking` and `@NonBlocking`, or both `@RunOnVirtualThread` and `@NonBlocking`. The build will fail if conflicting annotations are present.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -62,7 +62,7 @@ Build-time discovery::
 All `@JsonRPCApi` classes are found at build time via Jandex — no runtime classpath scanning, full ahead-of-time compilation and GraalVM native image support.
 
 Reactive and blocking::
-Return plain types for blocking execution, `Uni<T>` for async, or `Multi<T>` for streaming subscriptions. Fine-tune with `@Blocking` and `@NonBlocking`.
+Return plain types for blocking execution, `Uni<T>` for async, or `Multi<T>` for streaming subscriptions. Fine-tune with `@Blocking`, `@NonBlocking`, or `@RunOnVirtualThread`.
 
 Server push::
 Inject `JsonRPCBroadcaster` to send notifications to all connected clients or target a specific session.

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -23,6 +23,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCKeys;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
@@ -91,7 +92,7 @@ public class JsonRPCRouter {
                     javaMethod = providerInstance.getClass().getMethod(jsonRpcMethod.getMethodName());
                 }
                 ReflectionInfo reflectionInfo = new ReflectionInfo(jsonRpcMethod.getClazz(), providerInstance, javaMethod,
-                        params, jsonRpcMethod.getExplicitlyBlocking(), jsonRpcMethod.getExplicitlyNonBlocking());
+                        params, jsonRpcMethod.getExecutionMode());
                 jsonRpcToJava.put(methodName.toString(), reflectionInfo);
                 if (methodName.hasOrderedParameterKey()) {
                     orderedParameterKeyToNamedKey.put(methodName.getOrderedParameterKey(), methodName.toString());
@@ -147,46 +148,45 @@ public class JsonRPCRouter {
                 activated = true;
             }
             setSecurityIdentity(socket);
+            ExecutionMode mode = info.getExecutionMode();
             if (info.isReturningUni()) {
-                if (info.isExplicitlyBlocking()) {
+                if (mode == ExecutionMode.BLOCKING || mode == ExecutionMode.VIRTUAL_THREAD) {
                     SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
                     final Promise<?> result = Promise.promise();
-                    // We need some make sure that we call given the context
                     Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
                         Object resultFromMethodCall = info.method.invoke(target, args);
                         Uni<?> uniFromMethodCall = (Uni<?>) resultFromMethodCall;
                         return uniFromMethodCall.subscribeAsCompletionStage().get();
                     });
-                    vc.executeBlocking(contextualCallable).onComplete((Handler<AsyncResult<Object>>) result);
+                    dispatchBlocking(vc, contextualCallable, result, mode);
                     return Uni.createFrom().completionStage(result.future().toCompletionStage());
                 } else {
                     return (Uni<?>) info.method.invoke(target, args);
                 }
             } else if (info.isReturningCompletionStage()) {
-                if (info.isExplicitlyBlocking()) {
+                if (mode == ExecutionMode.BLOCKING || mode == ExecutionMode.VIRTUAL_THREAD) {
                     SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
                     final Promise<?> result = Promise.promise();
                     Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
                         CompletionStage<?> cs = (CompletionStage<?>) info.method.invoke(target, args);
                         return cs.toCompletableFuture().get();
                     });
-                    vc.executeBlocking(contextualCallable).onComplete((Handler<AsyncResult<Object>>) result);
+                    dispatchBlocking(vc, contextualCallable, result, mode);
                     return Uni.createFrom().completionStage(result.future().toCompletionStage());
                 } else {
                     CompletionStage<?> cs = (CompletionStage<?>) info.method.invoke(target, args);
                     return Uni.createFrom().completionStage(cs);
                 }
             } else {
-                if (info.isExplicitlyNonBlocking()) {
+                if (mode == ExecutionMode.NON_BLOCKING) {
                     return Uni.createFrom().item(Unchecked.supplier(() -> info.method.invoke(target, args)));
                 } else {
                     SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
                     final Promise<?> result = Promise.promise();
-                    // We need some make sure that we call given the context
                     Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
                         return info.method.invoke(target, args);
                     });
-                    vc.executeBlocking(contextualCallable).onComplete((Handler<AsyncResult<Object>>) result);
+                    dispatchBlocking(vc, contextualCallable, result, mode);
                     return Uni.createFrom().completionStage(result.future().toCompletionStage());
                 }
             }
@@ -196,6 +196,16 @@ public class JsonRPCRouter {
             if (activated) {
                 currentManagedContext.deactivate();
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void dispatchBlocking(Context vc, Callable<Object> callable, Promise<?> result,
+            ExecutionMode mode) {
+        if (mode == ExecutionMode.VIRTUAL_THREAD) {
+            VirtualThreadSupport.executeBlocking(callable, result);
+        } else {
+            vc.executeBlocking(callable).onComplete((Handler<AsyncResult<Object>>) result);
         }
     }
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/ReflectionInfo.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/ReflectionInfo.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow;
 
+import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -12,22 +13,20 @@ import io.smallrye.mutiny.Uni;
  * Contains reflection info on the beans that needs to be called from the jsonrpc router
  */
 public class ReflectionInfo {
-    private final boolean blocking;
-    private final boolean nonBlocking;
+    private final ExecutionMode executionMode;
     public Class bean;
     public Object instance;
     public Method method;
     public Map<String, Class> params;
     public java.lang.reflect.Type[] genericParameterTypes;
 
-    public ReflectionInfo(Class bean, Object instance, Method method, Map<String, Class> params, boolean explicitlyBlocking,
-            boolean explicitlyNonBlocking) {
+    public ReflectionInfo(Class bean, Object instance, Method method, Map<String, Class> params,
+            ExecutionMode executionMode) {
         this.bean = bean;
         this.instance = instance;
         this.method = method;
         this.params = params;
-        this.blocking = explicitlyBlocking;
-        this.nonBlocking = explicitlyNonBlocking;
+        this.executionMode = executionMode;
         this.genericParameterTypes = resolveGenericParameterTypes();
     }
 
@@ -60,11 +59,7 @@ public class ReflectionInfo {
         return Flow.Publisher.class.isAssignableFrom(method.getReturnType());
     }
 
-    public boolean isExplicitlyBlocking() {
-        return blocking;
-    }
-
-    public boolean isExplicitlyNonBlocking() {
-        return nonBlocking;
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/VirtualThreadSupport.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/VirtualThreadSupport.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
+import io.vertx.core.Promise;
+
+/**
+ * Isolates the {@code quarkus-virtual-threads} dependency so that
+ * {@link JsonRPCRouter} can be loaded even when the extension is absent.
+ * This class is only referenced when a method is annotated with
+ * {@code @RunOnVirtualThread}, which requires the extension at build time.
+ */
+final class VirtualThreadSupport {
+
+    private VirtualThreadSupport() {
+    }
+
+    @SuppressWarnings("unchecked")
+    static void executeBlocking(Callable<Object> callable, Promise<?> result) {
+        try {
+            ExecutorService executor = VirtualThreadsRecorder.getCurrent();
+            executor.submit(() -> {
+                try {
+                    ((Promise<Object>) result).complete(callable.call());
+                } catch (Throwable e) {
+                    result.fail(e);
+                }
+            });
+        } catch (Exception e) {
+            result.fail(e);
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
@@ -123,14 +123,19 @@ public class JsonRPCDevUIService {
     }
 
     private String getExecutionMode(ReflectionInfo info) {
-        if (info.isExplicitlyBlocking()) {
-            return "blocking";
-        } else if (info.isExplicitlyNonBlocking()) {
-            return "non-blocking";
-        } else if (info.isReturningUni() || info.isReturningMulti()
-                || info.isReturningCompletionStage() || info.isReturningFlowPublisher()) {
-            return "non-blocking (default)";
+        switch (info.getExecutionMode()) {
+            case BLOCKING:
+                return "blocking";
+            case NON_BLOCKING:
+                return "non-blocking";
+            case VIRTUAL_THREAD:
+                return "virtual thread";
+            default:
+                if (info.isReturningUni() || info.isReturningMulti()
+                        || info.isReturningCompletionStage() || info.isReturningFlowPublisher()) {
+                    return "non-blocking (default)";
+                }
+                return "blocking (default)";
         }
-        return "blocking (default)";
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/ExecutionMode.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/ExecutionMode.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.jsonrpc.runtime.model;
+
+public enum ExecutionMode {
+    DEFAULT,
+    BLOCKING,
+    NON_BLOCKING,
+    VIRTUAL_THREAD
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCMethod.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCMethod.java
@@ -7,8 +7,7 @@ public final class JsonRPCMethod {
     private String methodName;
     private Map<String, Class> params;
 
-    private boolean isExplicitlyBlocking;
-    private boolean isExplicitlyNonBlocking;
+    private ExecutionMode executionMode = ExecutionMode.DEFAULT;
 
     public JsonRPCMethod() {
     }
@@ -47,20 +46,12 @@ public final class JsonRPCMethod {
         this.params = params;
     }
 
-    public boolean getExplicitlyBlocking() {
-        return isExplicitlyBlocking;
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
     }
 
-    public void setExplicitlyBlocking(boolean blocking) {
-        isExplicitlyBlocking = blocking;
-    }
-
-    public boolean getExplicitlyNonBlocking() {
-        return isExplicitlyNonBlocking;
-    }
-
-    public void setExplicitlyNonBlocking(boolean nonblocking) {
-        isExplicitlyNonBlocking = nonblocking;
+    public void setExecutionMode(ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 
     @Override


### PR DESCRIPTION
JSON-RPC methods can now be annotated with `@RunOnVirtualThread` to run on virtual threads instead of the platform worker pool. This gives the straightforward blocking programming model with better scalability on Java 21+.

The `quarkus-virtual-threads` extension is an optional dependency — projects that don't use virtual threads are unaffected. Combining `@RunOnVirtualThread` with `@NonBlocking` is detected at build time and raises a clear error.

Closes #79