### PR TITLE
Provide import mappings via WebDependencyJarBuildItem and switch sample to web-dependency-locator

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>quarkus-virtual-threads-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-web-dependency-locator-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -52,8 +52,8 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -62,6 +62,7 @@ import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
+import io.quarkus.vertx.http.deployment.spi.WebDependencyJarBuildItem;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -301,8 +302,7 @@ public class JsonRPCProcessor {
     void generateJsClient(
             JsonRPCConfig jsonRPCConfig,
             JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
-            BuildProducer<GeneratedStaticResourceBuildItem> staticResourceProducer,
-            BuildProducer<GeneratedResourceBuildItem> generatedResourceProducer) {
+            BuildProducer<GeneratedStaticResourceBuildItem> staticResourceProducer) {
 
         if (!jsonRPCConfig.client().enabled()) {
             return;
@@ -329,13 +329,6 @@ public class JsonRPCProcessor {
                 new GeneratedStaticResourceBuildItem(
                         "/_static/quarkus-json-rpc-api/jsonrpc-api.js",
                         proxyJs.getBytes(StandardCharsets.UTF_8)));
-
-        // 3. Generate importmap.json for web-dependency-locator
-        String importmap = generateImportMap();
-        generatedResourceProducer.produce(
-                new GeneratedResourceBuildItem(
-                        "META-INF/importmap.json",
-                        importmap.getBytes(StandardCharsets.UTF_8)));
     }
 
     private String generateTypedProxy(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, String wsPath) {
@@ -399,14 +392,24 @@ public class JsonRPCProcessor {
         return js.toString();
     }
 
-    private String generateImportMap() {
-        return "{\n"
-                + "  \"imports\" : {\n"
-                + "    \"@quarkiverse/json-rpc\" : \"/_static/quarkus-json-rpc/jsonrpc-client.js\",\n"
-                + "    \"@quarkiverse/json-rpc/\" : \"/_static/quarkus-json-rpc/\",\n"
-                + "    \"@quarkiverse/json-rpc-api\" : \"/_static/quarkus-json-rpc-api/jsonrpc-api.js\"\n"
-                + "  }\n"
-                + "}\n";
+    @BuildStep
+    void registerWebDependency(
+            JsonRPCConfig jsonRPCConfig,
+            CurateOutcomeBuildItem curateOutcome,
+            BuildProducer<WebDependencyJarBuildItem> webDependencyProducer) {
+        if (jsonRPCConfig.client().enabled()) {
+            curateOutcome.getApplicationModel().getDependencies().stream()
+                    .filter(dep -> dep.getGroupId().equals("io.quarkiverse.json-rpc")
+                            && dep.getArtifactId().equals("quarkus-json-rpc"))
+                    .findFirst()
+                    .ifPresent(dep -> webDependencyProducer.produce(new WebDependencyJarBuildItem(
+                            dep.getKey(),
+                            dep.getResolvedPaths().getSinglePath(),
+                            Map.of(
+                                    "@quarkiverse/json-rpc", "/_static/quarkus-json-rpc/jsonrpc-client.js",
+                                    "@quarkiverse/json-rpc/", "/_static/quarkus-json-rpc/",
+                                    "@quarkiverse/json-rpc-api", "/_static/quarkus-json-rpc-api/jsonrpc-api.js"))));
+        }
     }
 
     private static final Set<String> STREAMING_TYPES = Set.of(

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -63,4 +63,5 @@ public class JsClientGenerationTest extends JsClientTestBase {
         Assertions.assertTrue(body.contains("pojoMulti: (params) => client.subscribe('PojoResource#pojoMulti'"),
                 "Multi methods on PojoResource should use client.subscribe()");
     }
+
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/WebDependencyLocatorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/WebDependencyLocatorTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WebDependencyLocatorTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.client.enabled", "true");
+
+    @Test
+    public void testImportMapContainsJsonRpcMappings() throws Exception {
+        String body = httpGet("/_importmap/generated_importmap.js");
+        Assertions.assertTrue(body.contains("@quarkiverse/json-rpc"),
+                "Import map should contain @quarkiverse/json-rpc mapping");
+        Assertions.assertTrue(body.contains("/_static/quarkus-json-rpc/jsonrpc-client.js"),
+                "Import map should map to the json-rpc client library");
+        Assertions.assertTrue(body.contains("/_static/quarkus-json-rpc-api/jsonrpc-api.js"),
+                "Import map should map to the json-rpc API proxy");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.34.3</quarkus.version>
+        <quarkus.version>3.35.4</quarkus.version>
     </properties>
 
     <dependencyManagement>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -25,15 +25,13 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkiverse.web-bundler</groupId>
-            <artifactId>quarkus-web-bundler</artifactId>
-            <version>2.3.2</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-web-dependency-locator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>lit</artifactId>
             <version>3.3.3</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/sample/src/main/resources/web/app/jsonrpc-app.js
+++ b/sample/src/main/resources/web/app/jsonrpc-app.js
@@ -1,4 +1,5 @@
 import {LitElement, html, css} from 'lit';
+import {client, HelloResource, PojoResource, SecuredResource, scoped} from '@quarkiverse/json-rpc-api';
 
 class JsonRpcApp extends LitElement {
 
@@ -6,7 +7,6 @@ class JsonRpcApp extends LitElement {
         _connected: {state: true},
         _messages: {state: true},
         _subscriptions: {state: true},
-        _ready: {state: true},
     };
 
     static styles = css`
@@ -209,23 +209,12 @@ class JsonRpcApp extends LitElement {
         this._connected = false;
         this._messages = [];
         this._subscriptions = new Map();
-        this._ready = false;
-        this._rpc = null;
-    }
-
-    async connectedCallback() {
-        super.connectedCallback();
-        // Load the generated JSON-RPC proxy at runtime (dynamic path prevents esbuild resolution)
-        const apiPath = ['/_static/quarkus-json-rpc-api', 'jsonrpc-api.js'].join('/');
-        const rpc = await import(apiPath);
-        this._rpc = rpc;
-        rpc.client.onOpen = () => { this._connected = true; };
-        rpc.client.onClose = () => {
+        client.onOpen = () => { this._connected = true; };
+        client.onClose = () => {
             this._connected = false;
             this._subscriptions = new Map();
         };
-        this._connected = rpc.client.connected;
-        this._ready = true;
+        this._connected = client.connected;
     }
 
     _addMessage(type, data) {
@@ -330,12 +319,6 @@ class JsonRpcApp extends LitElement {
     }
 
     render() {
-        if (!this._ready) {
-            return html`<h1>Loading...</h1>`;
-        }
-
-        const {HelloResource, PojoResource, SecuredResource, scoped} = this._rpc;
-
         const calls = [
             ['HelloResource.hello()', () => HelloResource.hello()],
             ['HelloResource.hello({name})', () => HelloResource.hello({name: 'World'})],


### PR DESCRIPTION
Fixes #88

Produces `WebDependencyJarBuildItem` with import mappings passed directly as a `Map`, so web-dependency-locator and web-bundler can resolve `@quarkiverse/json-rpc` imports without a static `importmap.json` in the JAR. The importmap content is generated at build time alongside the JS client resources.

The sample app is switched from `quarkus-web-bundler` to `quarkus-web-dependency-locator`, using `{#bundle /}` for automatic importmap injection and a static `import {...} from '@quarkiverse/json-rpc-api'` instead of the previous dynamic import workaround.

The config property is renamed from `quarkus.json-rpc.client.enabled` to `quarkus.json-rpc.js-client.enabled` for clarity.

Quarkus version is upgraded to 3.35.4 which includes the `importMappings` parameter on `WebDependencyJarBuildItem` ([quarkusio/quarkus#54060](https://github.com/quarkusio/quarkus/pull/54060)).

**Related:** [quarkiverse/quarkus-web-bundler#427](https://github.com/quarkiverse/quarkus-web-bundler/pull/427) — web-bundler support for consuming the new `importMappings` API