### PR TITLE
Add RAG documentation embeddings to release builds

### DIFF
--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -28,3 +28,4 @@ jobs:
     with:
       version: ${{github.event.inputs.tag || github.ref_name}}
       java_version: 17
+      maven_args: -Prag

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -10,6 +10,10 @@
     <artifactId>quarkus-json-rpc-deployment</artifactId>
     <name>Quarkus Json Rpc - Deployment</name>
 
+    <properties>
+        <quarkus-rag.guide>${project.basedir}/../docs/modules/ROOT/pages/index.adoc</quarkus-rag.guide>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
-        <version>21</version>
+        <version>22</version>
     </parent>
     <groupId>io.quarkiverse.json-rpc</groupId>
     <artifactId>quarkus-json-rpc-parent</artifactId>


### PR DESCRIPTION
Opts into the quarkiverse-parent RAG profile so that release builds generate `META-INF/quarkus-rag.sql` in the deployment JAR. This enables AI coding assistants (Quarkus Agent MCP, CHAPPiE) to include the extension's documentation in their vector search.

Changes:
- Bump quarkiverse-parent to 22 (includes the RAG profile)
- Set `quarkus-rag.guide` in the deployment module pointing to `index.adoc`
- Pass `-Prag` to the release workflow so the plugin only runs during releases, not CI builds