### PR TITLE
Rename config property from client.enabled to js-client.enabled

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -304,7 +304,7 @@ public class JsonRPCProcessor {
             JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
             BuildProducer<GeneratedStaticResourceBuildItem> staticResourceProducer) {
 
-        if (!jsonRPCConfig.client().enabled()) {
+        if (!jsonRPCConfig.jsClient().enabled()) {
             return;
         }
 
@@ -397,7 +397,7 @@ public class JsonRPCProcessor {
             JsonRPCConfig jsonRPCConfig,
             CurateOutcomeBuildItem curateOutcome,
             BuildProducer<WebDependencyJarBuildItem> webDependencyProducer) {
-        if (jsonRPCConfig.client().enabled()) {
+        if (jsonRPCConfig.jsClient().enabled()) {
             curateOutcome.getApplicationModel().getDependencies().stream()
                     .filter(dep -> dep.getGroupId().equals("io.quarkiverse.json-rpc")
                             && dep.getArtifactId().equals("quarkus-json-rpc"))

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
@@ -21,5 +21,6 @@ public interface JsonRPCConfig {
     /**
      * Configuration properties for the JavaScript client proxy generation
      */
-    JsonRPCClientConfig client();
+    @WithName("js-client")
+    JsonRPCClientConfig jsClient();
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientConflictingReturnTypeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientConflictingReturnTypeTest.java
@@ -14,7 +14,7 @@ public class JsClientConflictingReturnTypeTest {
             .withApplicationRoot(root -> {
                 root.addClasses(ConflictingReturnTypeResource.class);
             })
-            .overrideConfigKey("quarkus.json-rpc.client.enabled", "true")
+            .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true")
             .assertException(t -> {
                 Assertions.assertTrue(t instanceof IllegalArgumentException,
                         "Expected IllegalArgumentException but got: " + t.getClass().getName());

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientDisabledTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientDisabledTest.java
@@ -14,7 +14,7 @@ public class JsClientDisabledTest extends JsClientTestBase {
             .withApplicationRoot(root -> {
                 root.addClasses(HelloResource.class);
             })
-            .overrideConfigKey("quarkus.json-rpc.client.enabled", "false");
+            .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "false");
 
     @Test
     public void testClientLibraryNotServedWhenDisabled() throws Exception {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -17,7 +17,7 @@ public class JsClientGenerationTest extends JsClientTestBase {
             .withApplicationRoot(root -> {
                 root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class);
             })
-            .overrideConfigKey("quarkus.json-rpc.client.enabled", "true");
+            .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true");
 
     @Test
     public void testClientLibraryIsServed() throws Exception {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/WebDependencyLocatorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/WebDependencyLocatorTest.java
@@ -14,7 +14,7 @@ public class WebDependencyLocatorTest extends JsClientTestBase {
             .withApplicationRoot(root -> {
                 root.addClasses(HelloResource.class);
             })
-            .overrideConfigKey("quarkus.json-rpc.client.enabled", "true");
+            .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true");
 
     @Test
     public void testImportMapContainsJsonRpcMappings() throws Exception {

--- a/docs/modules/ROOT/pages/guides-javascript-client.adoc
+++ b/docs/modules/ROOT/pages/guides-javascript-client.adoc
@@ -2,7 +2,7 @@
 
 include::./includes/attributes.adoc[]
 
-When `quarkus.json-rpc.client.enabled` is set to `true`, the extension generates a JavaScript client library and a typed proxy module as web resources. These can be imported directly from frameworks like https://docs.quarkiverse.io/quarkus-web-bundler/dev/index.html[Quarkus Web Bundler] or https://quarkus.io/guides/web-dependency-locator[Web Dependency Locator] via the standard https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap[import map] convention.
+When `quarkus.json-rpc.js-client.enabled` is set to `true`, the extension generates a JavaScript client library and a typed proxy module as web resources. These can be imported directly from frameworks like https://docs.quarkiverse.io/quarkus-web-bundler/dev/index.html[Quarkus Web Bundler] or https://quarkus.io/guides/web-dependency-locator[Web Dependency Locator] via the standard https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap[import map] convention.
 
 == Enabling the Client
 
@@ -10,7 +10,7 @@ Add to `application.properties`:
 
 [source,properties]
 ----
-quarkus.json-rpc.client.enabled=true
+quarkus.json-rpc.js-client.enabled=true
 ----
 
 This generates three resources at build time:

--- a/docs/modules/ROOT/pages/includes/quarkus-json-rpc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-json-rpc.adoc
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |`/quarkus/json-rpc`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-json-rpc_quarkus-json-rpc-client-enabled]]`link:#quarkus-json-rpc_quarkus-json-rpc-client-enabled[quarkus.json-rpc.client.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-json-rpc_quarkus-json-rpc-js-client-enabled]]`link:#quarkus-json-rpc_quarkus-json-rpc-js-client-enabled[quarkus.json-rpc.js-client.enabled]`
 
 
 [.description]
@@ -52,10 +52,10 @@ a|icon:lock[title=Fixed at build time] [[quarkus-json-rpc_quarkus-json-rpc-clien
 Generate a JavaScript client proxy for all discovered JSON-RPC endpoints. When enabled, a static client library and a typed proxy module are generated as web resources, along with an import map following the mvnpm convention.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_JSON_RPC_CLIENT_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_JSON_RPC_JS_CLIENT_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_JSON_RPC_CLIENT_ENABLED+++`
+Environment variable: `+++QUARKUS_JSON_RPC_JS_CLIENT_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --|boolean
 |`false`

--- a/sample/src/main/resources/application.properties
+++ b/sample/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.json-rpc.client.enabled=true
+quarkus.json-rpc.js-client.enabled=true
 
 # Security: Basic auth with embedded users
 quarkus.http.auth.basic=true


### PR DESCRIPTION
The property `quarkus.json-rpc.client.enabled` is vague about what it controls. Renamed to `quarkus.json-rpc.js-client.enabled` to make it clear this toggles JavaScript client proxy generation.

No one is using this config yet so there is no backwards compatibility concern.