### PR TITLE
Add documentation and sample for collections, maps and optionals

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -4,6 +4,7 @@
 ** xref:guides-creating-api.adoc[Creating an API]
 ** xref:guides-execution-modes.adoc[Execution Modes & Return Types]
 ** xref:guides-parameters.adoc[Parameters]
+** xref:guides-collections.adoc[Collections, Maps & Optionals]
 ** xref:guides-streaming.adoc[Streaming with Multi]
 ** xref:guides-broadcasting.adoc[Broadcasting]
 ** xref:guides-security.adoc[Security]

--- a/docs/modules/ROOT/pages/guides-collections.adoc
+++ b/docs/modules/ROOT/pages/guides-collections.adoc
@@ -1,0 +1,261 @@
+= Collections, Maps & Optionals
+
+include::./includes/attributes.adoc[]
+
+The extension fully supports Java collection types — `List`, `Set`, `Map`, `Optional`, and arrays — as both return types and method parameters. Generic type information is preserved at runtime, so Jackson deserializes parameterized types like `List<Pojo>` or `Map<String, Pojo>` correctly.
+
+== Returning Collections
+
+Methods can return `List<T>`, `Set<T>`, or `T[]`. The result is serialized as a JSON array:
+
+[source,java]
+----
+@JsonRPCApi
+public class InventoryService {
+
+    public List<String> categories() {
+        return List.of("electronics", "books", "clothing");
+    }
+
+    public List<Product> featured() {
+        return List.of(
+            new Product("Laptop", 999.99),
+            new Product("Novel", 12.99)
+        );
+    }
+
+    public Set<String> tags() {
+        return Set.of("sale", "new", "popular");
+    }
+}
+----
+
+Response for `InventoryService#categories`:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": ["electronics", "books", "clothing"]
+}
+----
+
+Response for `InventoryService#featured`:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": [
+    { "name": "Laptop", "price": 999.99 },
+    { "name": "Novel", "price": 12.99 }
+  ]
+}
+----
+
+== Returning Maps
+
+Methods can return `Map<K, V>`. The result is serialized as a JSON object:
+
+[source,java]
+----
+@JsonRPCApi
+public class ConfigService {
+
+    public Map<String, String> settings() {
+        return Map.of(
+            "theme", "dark",
+            "language", "en"
+        );
+    }
+
+    public Map<String, Product> catalog() {
+        Map<String, Product> map = new LinkedHashMap<>();
+        map.put("laptop", new Product("Laptop", 999.99));
+        map.put("novel", new Product("Novel", 12.99));
+        return map;
+    }
+}
+----
+
+Response for `ConfigService#settings`:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "theme": "dark",
+    "language": "en"
+  }
+}
+----
+
+Response for `ConfigService#catalog`:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "laptop": { "name": "Laptop", "price": 999.99 },
+    "novel": { "name": "Novel", "price": 12.99 }
+  }
+}
+----
+
+== Returning Optionals
+
+Methods can return `Optional<T>`. A present value is unwrapped and serialized normally; an empty optional results in `null`:
+
+[source,java]
+----
+@JsonRPCApi
+public class LookupService {
+
+    public Optional<String> findNickname(String username) {
+        return nicknameStore.get(username);
+    }
+}
+----
+
+When the value is present:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "Johnny"
+}
+----
+
+When the value is empty:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": null
+}
+----
+
+== Collections as Parameters
+
+Collection types work as method parameters too. The extension preserves generic type information so Jackson deserializes `List<Pojo>`, `Map<String, Pojo>`, etc. correctly.
+
+=== List parameters
+
+[source,java]
+----
+@JsonRPCApi
+public class BatchService {
+
+    public String joinNames(List<String> names) {
+        return String.join(", ", names);
+    }
+}
+----
+
+Using named parameters:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "BatchService#joinNames",
+  "params": {
+    "names": ["Alice", "Bob", "Charlie"]
+  }
+}
+----
+
+Using positional parameters:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "BatchService#joinNames",
+  "params": [["Alice", "Bob", "Charlie"]]
+}
+----
+
+=== Map parameters
+
+[source,java]
+----
+@JsonRPCApi
+public class BatchService {
+
+    public String lookup(Map<String, String> data, String key) {
+        return data.get(key);
+    }
+}
+----
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "BatchService#lookup",
+  "params": {
+    "data": { "host": "localhost", "port": "8080" },
+    "key": "host"
+  }
+}
+----
+
+=== Array parameters
+
+[source,java]
+----
+@JsonRPCApi
+public class BatchService {
+
+    public int count(String[] items) {
+        return items.length;
+    }
+}
+----
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "BatchService#count",
+  "params": {
+    "items": ["a", "b", "c"]
+  }
+}
+----
+
+== Async Variants
+
+All collection and map types work with `Uni<T>` for async execution:
+
+[source,java]
+----
+@JsonRPCApi
+public class AsyncInventoryService {
+
+    public Uni<List<String>> categories() {
+        return categoryRepository.listAll();
+    }
+
+    public Uni<Map<String, Product>> catalog() {
+        return catalogRepository.loadCatalog();
+    }
+}
+----
+
+These follow the same execution semantics described in xref:guides-execution-modes.adoc[Execution Modes & Return Types].

--- a/docs/modules/ROOT/pages/guides-collections.adoc
+++ b/docs/modules/ROOT/pages/guides-collections.adoc
@@ -214,6 +214,51 @@ public class BatchService {
 }
 ----
 
+=== Optional parameters
+
+`Optional<T>` can be used as a method parameter. Pass the value directly (or `null` for empty):
+
+[source,java]
+----
+@JsonRPCApi
+public class BatchService {
+
+    public String withDefault(String name, Optional<String> title) {
+        return title.map(t -> t + " " + name).orElse(name);
+    }
+}
+----
+
+With a value present:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "BatchService#withDefault",
+  "params": {
+    "name": "Alice",
+    "title": "Dr."
+  }
+}
+----
+
+With an empty optional (pass `null`):
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "BatchService#withDefault",
+  "params": {
+    "name": "Alice",
+    "title": null
+  }
+}
+----
+
 === Array parameters
 
 [source,java]

--- a/docs/modules/ROOT/pages/guides-parameters.adoc
+++ b/docs/modules/ROOT/pages/guides-parameters.adoc
@@ -57,8 +57,7 @@ The extension uses Jackson for deserialization, so any type that Jackson can han
 - **Primitives and wrappers**: `int`, `long`, `boolean`, `double`, `String`, etc.
 - **Java time types**: `LocalDateTime`, `LocalDate`, `Instant`, etc.
 - **UUID**: `java.util.UUID`
-- **Collections**: `List<T>`, `Set<T>`, `Map<K,V>`
-- **Arrays**: `T[]`
+- **Collections, Maps, Optionals, and Arrays**: `List<T>`, `Set<T>`, `Map<K,V>`, `Optional<T>`, `T[]` — see xref:guides-collections.adoc[Collections, Maps & Optionals] for details and examples
 - **POJOs**: any class with a default constructor and getters/setters
 
 == Complex Object Parameters

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/CollectionResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/CollectionResource.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.jsonrpc.sample;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.quarkiverse.jsonrpc.sample.model.Pojo;
+import io.quarkiverse.jsonrpc.sample.model.Pojo2;
+
+@JsonRPCApi
+public class CollectionResource {
+
+    public List<String> listOfStrings() {
+        return List.of("alpha", "beta", "gamma");
+    }
+
+    public List<Pojo> listOfPojos() {
+        return List.of(createPojo("Alice"), createPojo("Bob"));
+    }
+
+    public Map<String, String> mapOfStrings() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("theme", "dark");
+        map.put("language", "en");
+        return map;
+    }
+
+    public Map<String, Pojo> mapOfPojos() {
+        Map<String, Pojo> map = new LinkedHashMap<>();
+        map.put("alice", createPojo("Alice"));
+        map.put("bob", createPojo("Bob"));
+        return map;
+    }
+
+    public Set<String> setOfStrings() {
+        return Set.of("one", "two", "three");
+    }
+
+    public Optional<String> optionalPresent() {
+        return Optional.of("present-value");
+    }
+
+    public Optional<String> optionalEmpty() {
+        return Optional.empty();
+    }
+
+    public String joinStrings(List<String> items) {
+        return String.join(", ", items);
+    }
+
+    public String lookupInMap(Map<String, String> data, String key) {
+        return data.get(key);
+    }
+
+    private Pojo createPojo(String name) {
+        Pojo pojo = new Pojo();
+        pojo.setName(name);
+        pojo.setSurname("Sample");
+        pojo.setThread(Thread.currentThread().getName());
+        pojo.setTime(LocalDateTime.now());
+        pojo.setPojo2(new Pojo2(0, "collection-sample", UUID.randomUUID()));
+        return pojo;
+    }
+}

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/CollectionResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/CollectionResource.java
@@ -57,6 +57,10 @@ public class CollectionResource {
         return data.get(key);
     }
 
+    public String withDefault(String name, Optional<String> title) {
+        return title.map(t -> t + " " + name).orElse(name);
+    }
+
     private Pojo createPojo(String name) {
         Pojo pojo = new Pojo();
         pojo.setName(name);

--- a/sample/src/main/resources/web/app/jsonrpc-app.js
+++ b/sample/src/main/resources/web/app/jsonrpc-app.js
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'lit';
-import {client, HelloResource, PojoResource, SecuredResource, scoped} from '@quarkiverse/json-rpc-api';
+import {client, HelloResource, PojoResource, CollectionResource, SecuredResource, scoped} from '@quarkiverse/json-rpc-api';
 
 class JsonRpcApp extends LitElement {
 
@@ -334,6 +334,20 @@ class JsonRpcApp extends LitElement {
             ['scoped.pojo()', () => scoped.pojo()],
         ];
 
+        const collectionCalls = [
+            ['CollectionResource.listOfStrings()', () => CollectionResource.listOfStrings()],
+            ['CollectionResource.listOfPojos()', () => CollectionResource.listOfPojos()],
+            ['CollectionResource.mapOfStrings()', () => CollectionResource.mapOfStrings()],
+            ['CollectionResource.mapOfPojos()', () => CollectionResource.mapOfPojos()],
+            ['CollectionResource.setOfStrings()', () => CollectionResource.setOfStrings()],
+            ['CollectionResource.optionalPresent()', () => CollectionResource.optionalPresent()],
+            ['CollectionResource.optionalEmpty()', () => CollectionResource.optionalEmpty()],
+            ['CollectionResource.joinStrings({items})', () => CollectionResource.joinStrings({items: ['alpha', 'beta', 'gamma']})],
+            ['CollectionResource.lookupInMap({data, key})', () => CollectionResource.lookupInMap({data: {host: 'localhost', port: '8080'}, key: 'host'})],
+            ['CollectionResource.withDefault({name, title})', () => CollectionResource.withDefault({name: 'Alice', title: 'Dr.'})],
+            ['CollectionResource.withDefault({name}) no title', () => CollectionResource.withDefault({name: 'Alice', title: null})],
+        ];
+
         const securedCalls = [
             ['adminSecret() @RolesAllowed("admin")', () => SecuredResource.adminSecret()],
             ['adminGreeting({name}) @RolesAllowed("admin")', () => SecuredResource.adminGreeting({name: 'Boss'})],
@@ -360,6 +374,15 @@ class JsonRpcApp extends LitElement {
                     <label>Click a method to invoke it</label>
                     <div class="quick-methods">
                         ${calls.map(([label, fn]) =>
+                            html`<button ?disabled=${!this._connected}
+                                         @click=${() => this._call(label, fn)}>${label}</button>`
+                        )}
+                    </div>
+
+                    <h2>Collections, Maps & Optionals</h2>
+                    <label>Methods returning or accepting collections, maps, and optionals</label>
+                    <div class="quick-methods">
+                        ${collectionCalls.map(([label, fn]) =>
                             html`<button ?disabled=${!this._connected}
                                          @click=${() => this._call(label, fn)}>${label}</button>`
                         )}


### PR DESCRIPTION
Collections (`List`, `Set`), `Map`, and `Optional` are fully supported as both return types and method parameters, but this wasn't documented beyond a single bullet point in the parameters guide, and the sample app had no examples.

This adds a dedicated documentation page (`guides-collections.adoc`) covering returning collections, maps, and optionals, using them as parameters (with JSON request/response examples for each), and async variants with `Uni<T>`. It also adds a `CollectionResource` to the sample module demonstrating these types in practice.