### PR TITLE
Use IoUtil.readBytes() and fix token resolution from static config

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -54,6 +54,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -317,7 +318,7 @@ public class JsonRPCProcessor {
             staticResourceProducer.produce(
                     new GeneratedStaticResourceBuildItem(
                             "/_static/quarkus-json-rpc/jsonrpc-client.js",
-                            is.readAllBytes()));
+                            IoUtil.readBytes(is)));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -271,10 +271,11 @@ export class JsonRPCClient {
     }
 
     _resolveToken() {
-        if (this._tokenProvider) {
-            return this._tokenProvider();
+        const provider = this._tokenProvider || JsonRPCClient._config.tokenProvider;
+        if (provider) {
+            return provider();
         }
-        return this._token;
+        return this._token || JsonRPCClient._config.token || null;
     }
 
     _buildProtocols(token) {


### PR DESCRIPTION
Two fixes:

- Use `IoUtil.readBytes()` instead of `is.readAllBytes()` for classpath resource loading, consistent with Quarkus conventions
- Fix `_resolveToken()` to check the static `_config` at call time, not just the constructor-captured values. This ensures `JsonRPCClient.configure({ tokenProvider: ... })` works on the already-created client singleton in the generated proxy