### PR TITLE
Use bare import specifier in generated proxy

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -334,7 +334,7 @@ public class JsonRPCProcessor {
 
     private String generateTypedProxy(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, String wsPath) {
         StringBuilder js = new StringBuilder();
-        js.append("import { JsonRPCClient } from '/_static/quarkus-json-rpc/jsonrpc-client.js';\n\n");
+        js.append("import { JsonRPCClient } from '@quarkiverse/json-rpc';\n\n");
         js.append("export const client = new JsonRPCClient({ path: '").append(escapeJsString(wsPath)).append("' });\n\n");
 
         // Group methods by scope and method name (sorted for deterministic output).


### PR DESCRIPTION
The generated proxy should use `import { JsonRPCClient } from '@quarkiverse/json-rpc'` instead of the `/_static/` path, since the import map resolves it. This is consistent with how user code imports the typed proxy.