### PR TITLE
Fix JsClientGenerationTest to expect bare import specifier

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -31,8 +31,8 @@ public class JsClientGenerationTest extends JsClientTestBase {
     @Test
     public void testTypedProxyIsServed() throws Exception {
         String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
-        Assertions.assertTrue(body.contains("import { JsonRPCClient } from '/_static/quarkus-json-rpc/jsonrpc-client.js'"),
-                "Proxy should import from absolute path");
+        Assertions.assertTrue(body.contains("import { JsonRPCClient } from '@quarkiverse/json-rpc'"),
+                "Proxy should import using bare import specifier");
         Assertions.assertTrue(body.contains("export const client = new JsonRPCClient({ path: '/quarkus/json-rpc' })"),
                 "Proxy should export a client instance with configured path");
     }


### PR DESCRIPTION
The test was still asserting the generated proxy imports from the absolute path `/_static/quarkus-json-rpc/jsonrpc-client.js`, but since PR #115 the proxy uses the bare specifier `@quarkiverse/json-rpc`. This is what caused the CI failure on PR #117.