### PR TITLE
Change default WebSocket path from /quarkus/json-rpc to /json-rpc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ This follows the standard Quarkus extension split:
 
 **Configuration** (build-time):
 - `quarkus.json-rpc.web-socket.enabled` (default: `true`)
-- `quarkus.json-rpc.web-socket.path` (default: `/quarkus/json-rpc`)
+- `quarkus.json-rpc.web-socket.path` (default: `/json-rpc`)
 
 ## Testing Patterns
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ public class GreetingService {
 
 ### 3. Call it over WebSocket
 
-Connect to `ws://localhost:8080/quarkus/json-rpc` and send:
+Connect to `ws://localhost:8080/json-rpc` and send:
 
 ```json
 {

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCWebSocketConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCWebSocketConfig.java
@@ -13,6 +13,6 @@ public interface JsonRPCWebSocketConfig {
     /**
      * HTTP Path for the JsonRPC Websocket
      */
-    @WithDefault("/quarkus/json-rpc")
+    @WithDefault("/json-rpc")
     String path();
 }

--- a/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -51,5 +51,5 @@ public class GreetingService {
 ### Testing
 
 - Use `QuarkusUnitTest` with Vert.x `WebSocketClient` to test JSON-RPC methods.
-- Connect to the WebSocket endpoint at the configured path (default: `/quarkus/json-rpc`).
+- Connect to the WebSocket endpoint at the configured path (default: `/json-rpc`).
 - Send JSON-RPC 2.0 request messages and assert on the response.

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -41,7 +41,7 @@ export class JsonRPCClient {
 
     constructor(options = {}) {
         const merged = { ...JsonRPCClient._config, ...options };
-        this._path = merged.path || '/quarkus/json-rpc';
+        this._path = merged.path || '/json-rpc';
         this._url = merged.url || null;
         this._autoReconnect = merged.autoReconnect !== false;
         this._reconnectDelay = 1000;

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/BroadcastJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/BroadcastJsonRpcTest.java
@@ -31,7 +31,7 @@ public class BroadcastJsonRpcTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/FlowPublisherJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/FlowPublisherJsonRpcTest.java
@@ -30,7 +30,7 @@ public class FlowPublisherJsonRpcTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -33,7 +33,7 @@ public class JsClientGenerationTest extends JsClientTestBase {
         String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
         Assertions.assertTrue(body.contains("import { JsonRPCClient } from '@quarkiverse/json-rpc'"),
                 "Proxy should import using bare import specifier");
-        Assertions.assertTrue(body.contains("export const client = new JsonRPCClient({ path: '/quarkus/json-rpc' })"),
+        Assertions.assertTrue(body.contains("export const client = new JsonRPCClient({ path: '/json-rpc' })"),
                 "Proxy should export a client instance with configured path");
     }
 

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
@@ -27,7 +27,7 @@ public class JsonRpcParent {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     protected String getJsonRpcResponse(String providedInput) throws Exception {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MultiJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MultiJsonRpcTest.java
@@ -32,7 +32,7 @@ public class MultiJsonRpcTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityHttpPolicyJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityHttpPolicyJsonRpcTest.java
@@ -40,7 +40,7 @@ public class SecurityHttpPolicyJsonRpcTest {
                 root.addClasses(HelloResource.class);
                 root.addAsResource(new org.jboss.shrinkwrap.api.asset.StringAsset(
                         "quarkus.http.auth.basic=true\n" +
-                                "quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc\n" +
+                                "quarkus.http.auth.permission.json-rpc.paths=/json-rpc\n" +
                                 "quarkus.http.auth.permission.json-rpc.policy=authenticated\n" +
                                 "quarkus.security.users.embedded.enabled=true\n" +
                                 "quarkus.security.users.embedded.plain-text=true\n" +
@@ -52,7 +52,7 @@ public class SecurityHttpPolicyJsonRpcTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecurityJsonRpcTest.java
@@ -52,7 +52,7 @@ public class SecurityJsonRpcTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     // --- Admin role tests ---

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecuritySubProtocolJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/SecuritySubProtocolJsonRpcTest.java
@@ -52,7 +52,7 @@ public class SecuritySubProtocolJsonRpcTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     @Test

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -83,7 +83,7 @@ public class OrderService {
 All JSON-RPC methods are served through a single WebSocket endpoint. By default, this is:
 
 ----
-ws://localhost:8080/quarkus/json-rpc
+ws://localhost:8080/json-rpc
 ----
 
 See xref:reference-configuration.adoc[Configuration Reference] to change the path.

--- a/docs/modules/ROOT/pages/guides-javascript-client.adoc
+++ b/docs/modules/ROOT/pages/guides-javascript-client.adoc
@@ -72,7 +72,7 @@ The typed proxy exports the `client` instance so you can reconfigure the WebSock
 import { client, GreetingService } from '@quarkiverse/json-rpc-api';
 
 // Override the full URL
-client.url = 'wss://gateway.example.com/quarkus/json-rpc';
+client.url = 'wss://gateway.example.com/json-rpc';
 
 // Or just change the path
 client.path = '/api/json-rpc';
@@ -90,7 +90,7 @@ If you prefer more control, import the `JsonRPCClient` class directly:
 import { JsonRPCClient } from '@quarkiverse/json-rpc';
 
 const client = new JsonRPCClient({
-    path: '/quarkus/json-rpc',   // WebSocket path (default)
+    path: '/json-rpc',   // WebSocket path (default)
     autoReconnect: true,         // Reconnect on disconnect (default)
     maxReconnectDelay: 30000     // Max backoff in ms (default)
 });
@@ -193,7 +193,7 @@ const client = new JsonRPCClient({
 
 | `path`
 | `string`
-| `'/quarkus/json-rpc'`
+| `'/json-rpc'`
 | WebSocket endpoint path
 
 | `url`

--- a/docs/modules/ROOT/pages/guides-security.adoc
+++ b/docs/modules/ROOT/pages/guides-security.adoc
@@ -110,7 +110,7 @@ You can also secure the entire WebSocket endpoint at the HTTP level using standa
 [source,properties]
 ----
 # Require authentication for the JSON-RPC endpoint
-quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc
+quarkus.http.auth.permission.json-rpc.paths=/json-rpc
 quarkus.http.auth.permission.json-rpc.policy=authenticated
 ----
 
@@ -122,7 +122,7 @@ You can restrict access to specific roles at the HTTP level:
 
 [source,properties]
 ----
-quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc
+quarkus.http.auth.permission.json-rpc.paths=/json-rpc
 quarkus.http.auth.permission.json-rpc.policy=role-policy
 
 quarkus.http.auth.policy.role-policy.roles-allowed=admin,operator
@@ -139,7 +139,7 @@ For example, require authentication to connect, then use `@RolesAllowed` to rest
 
 [source,properties]
 ----
-quarkus.http.auth.permission.json-rpc.paths=/quarkus/json-rpc
+quarkus.http.auth.permission.json-rpc.paths=/json-rpc
 quarkus.http.auth.permission.json-rpc.policy=authenticated
 ----
 
@@ -182,7 +182,7 @@ Connect with credentials from a Java or Node.js client (which supports custom he
 [source,javascript]
 ----
 // Node.js — custom headers are supported
-const ws = new WebSocket('ws://localhost:8080/quarkus/json-rpc', {
+const ws = new WebSocket('ws://localhost:8080/json-rpc', {
     headers: { Authorization: 'Basic ' + btoa('admin:secret') }
 });
 ----

--- a/docs/modules/ROOT/pages/includes/quarkus-json-rpc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-json-rpc.adoc
@@ -41,7 +41,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_JSON_RPC_WEB_SOCKET_PATH+++`
 endif::add-copy-button-to-env-var[]
 --|string
-|`/quarkus/json-rpc`
+|`/json-rpc`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-json-rpc_quarkus-json-rpc-js-client-enabled]]`link:#quarkus-json-rpc_quarkus-json-rpc-js-client-enabled[quarkus.json-rpc.js-client.enabled]`

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,7 +20,7 @@ public class GreetingService {
 }
 ----
 
-Connect to `ws://localhost:8080/quarkus/json-rpc` and send:
+Connect to `ws://localhost:8080/json-rpc` and send:
 
 [source,json]
 ----

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-quarkus.json-rpc.web-socket.path=/quarkus/json-rpc
+quarkus.json-rpc.web-socket.path=/json-rpc

--- a/integration-tests/src/test/java/io/quarkiverse/json/rpc/it/JsonRpcWebSocketTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/json/rpc/it/JsonRpcWebSocketTest.java
@@ -22,7 +22,7 @@ public class JsonRpcWebSocketTest {
     @Inject
     Vertx vertx;
 
-    @TestHTTPResource("quarkus/json-rpc")
+    @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
     @Test


### PR DESCRIPTION
The default WebSocket endpoint path `/quarkus/json-rpc` leaks information about the backend framework. This changes it to `/json-rpc` which is framework-neutral.

The path remains fully configurable via `quarkus.json-rpc.web-socket.path` for users who want a custom value.

Fixes #94