### PR TITLE
Trigger hot reload on WebSocket JSON-RPC requests in dev mode

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcDevModeTest.java
@@ -44,7 +44,8 @@ public class JsonRpcDevModeTest {
                             ws.writeTextMessage(
                                     JsonObject.of("jsonrpc", "2.0", "id", id, "method", method).encode());
                         } else {
-                            messages.add("{\"error\":{\"message\":\"" + r.cause().getMessage() + "\"}}");
+                            messages.add(JsonObject.of("error",
+                                    JsonObject.of("message", r.cause().getMessage())).encode());
                         }
                     });
             String response = messages.poll(10, TimeUnit.SECONDS);

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcDevModeTest.java
@@ -1,23 +1,60 @@
 package io.quarkiverse.jsonrpc.deployment;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.HelloResource;
 import io.quarkus.test.QuarkusDevModeTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonObject;
 
 public class JsonRpcDevModeTest {
 
-    // Start hot reload (DevMode) test with your extension loaded
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
 
     @Test
-    public void writeYourOwnDevModeTest() {
-        // Write your dev mode tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
-        Assertions.assertTrue(true, "Add dev mode assertions to " + getClass().getName());
+    public void testHotReloadViaWebSocket() throws Exception {
+        String result1 = callJsonRpc("HelloResource#hello", 1);
+        Assertions.assertTrue(result1.startsWith("Hello ["), "Initial response: " + result1);
+
+        devModeTest.modifySourceFile(HelloResource.class,
+                s -> s.replace("return \"Hello [\"", "return \"Hola [\""));
+
+        String result2 = callJsonRpc("HelloResource#hello", 2);
+        Assertions.assertTrue(result2.startsWith("Hola ["), "After hot reload: " + result2);
+    }
+
+    private String callJsonRpc(String method, int id) throws Exception {
+        Vertx vertx = Vertx.vertx();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            client.connect(8080, "localhost", "/json-rpc")
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(
+                                    JsonObject.of("jsonrpc", "2.0", "id", id, "method", method).encode());
+                        } else {
+                            messages.add("{\"error\":{\"message\":\"" + r.cause().getMessage() + "\"}}");
+                        }
+                    });
+            String response = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received");
+            JsonObject json = new JsonObject(response);
+            Assertions.assertNull(json.getJsonObject("error"), "Unexpected error: " + response);
+            return json.getString("result");
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+            vertx.close().toCompletionStage().toCompletableFuture().get();
+        }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHotReplacementSetup.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHotReplacementSetup.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.quarkus.dev.spi.HotReplacementSetup;
+
+public class JsonRPCHotReplacementSetup implements HotReplacementSetup {
+
+    private static volatile HotReplacementContext context;
+
+    private static final long HOT_REPLACEMENT_INTERVAL = 2000L;
+    private static volatile long nextUpdate;
+
+    @Override
+    public void setupHotDeployment(HotReplacementContext ctx) {
+        context = ctx;
+    }
+
+    static boolean scan() {
+        HotReplacementContext ctx = context;
+        if (ctx == null) {
+            return false;
+        }
+        long now = System.currentTimeMillis();
+        if (nextUpdate > now) {
+            return false;
+        }
+        synchronized (JsonRPCHotReplacementSetup.class) {
+            if (nextUpdate > now) {
+                return false;
+            }
+            nextUpdate = now + HOT_REPLACEMENT_INTERVAL;
+            try {
+                return ctx.doScan(true);
+            } catch (Exception e) {
+                throw new RuntimeException("JSON-RPC hot reload scan failed", e);
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHotReplacementSetup.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHotReplacementSetup.java
@@ -15,7 +15,11 @@ public class JsonRPCHotReplacementSetup implements HotReplacementSetup {
         context = ctx;
     }
 
-    static boolean scan() {
+    static boolean isEnabled() {
+        return context != null;
+    }
+
+    static boolean scan() throws Exception {
         HotReplacementContext ctx = context;
         if (ctx == null) {
             return false;
@@ -29,11 +33,7 @@ public class JsonRPCHotReplacementSetup implements HotReplacementSetup {
                 return false;
             }
             nextUpdate = now + HOT_REPLACEMENT_INTERVAL;
-            try {
-                return ctx.doScan(true);
-            } catch (Exception e) {
-                throw new RuntimeException("JSON-RPC hot reload scan failed", e);
-            }
+            return ctx.doScan(true);
         }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -248,6 +248,8 @@ public class JsonRPCRouter {
 
     @SuppressWarnings("unchecked")
     private void route(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
+        JsonRPCHotReplacementSetup.scan();
+
         // Handle unsubscribe requests before normal method lookup
         if (JsonRPCKeys.UNSUBSCRIBE.equals(jsonRpcRequest.getMethod())) {
             handleUnsubscribe(jsonRpcRequest, s);

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -246,10 +246,24 @@ public class JsonRPCRouter {
         });
     }
 
-    @SuppressWarnings("unchecked")
     private void route(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
-        JsonRPCHotReplacementSetup.scan();
+        if (JsonRPCHotReplacementSetup.isEnabled()) {
+            Vertx.currentContext().<Void> executeBlocking(() -> {
+                JsonRPCHotReplacementSetup.scan();
+                return null;
+            }).onComplete(ar -> {
+                if (ar.failed()) {
+                    LOG.warnf(ar.cause(), "JSON-RPC hot reload scan failed");
+                }
+                dispatchRoute(jsonRpcRequest, s);
+            });
+        } else {
+            dispatchRoute(jsonRpcRequest, s);
+        }
+    }
 
+    @SuppressWarnings("unchecked")
+    private void dispatchRoute(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
         // Handle unsubscribe requests before normal method lookup
         if (JsonRPCKeys.UNSUBSCRIBE.equals(jsonRpcRequest.getMethod())) {
             handleUnsubscribe(jsonRpcRequest, s);

--- a/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
+++ b/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
@@ -1,0 +1,1 @@
+io.quarkiverse.jsonrpc.runtime.JsonRPCHotReplacementSetup


### PR DESCRIPTION
In dev mode, HTTP requests automatically trigger a hot reload scan before being handled. But JSON-RPC requests arrive over an already-established WebSocket connection, bypassing that check entirely. This means code changes to `@JsonRPCApi` classes aren't picked up until something else triggers a reload.

This adds a `HotReplacementSetup` SPI implementation that hooks into the Quarkus dev mode lifecycle. Before each JSON-RPC request is dispatched, a scan is triggered (throttled to every 2 seconds, matching the HTTP handler behavior). In production the setup class is never loaded, so there's zero overhead.

The placeholder dev mode test is replaced with a real test that modifies a source file and verifies the change is picked up over WebSocket.

Fixes #17