### PR TITLE
Add automatic Micrometer metrics for JSON-RPC invocations

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>quarkus-web-dependency-locator-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -53,6 +54,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -262,6 +264,16 @@ public class JsonRPCProcessor {
                     .createWith(recorder.createJsonRpcBroadcaster())
                     .scope(ApplicationScoped.class)
                     .done());
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void registerMetrics(
+            JsonRPCRecorder recorder,
+            Optional<MetricsCapabilityBuildItem> metricsCapability) {
+        if (metricsCapability.isPresent()) {
+            recorder.initMetrics();
         }
     }
 

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -274,6 +274,8 @@ public class JsonRPCProcessor {
             Optional<MetricsCapabilityBuildItem> metricsCapability) {
         if (metricsCapability.isPresent()) {
             recorder.initMetrics();
+        } else {
+            recorder.clearMetrics();
         }
     }
 

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/FailingResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/FailingResource.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class FailingResource {
+
+    public String fail() {
+        throw new RuntimeException("expected test error");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
@@ -94,8 +94,11 @@ public class MetricsJsonRpcTest {
             CompletableFuture<Void> closed = new CompletableFuture<>();
             ws.close().onComplete(r -> closed.complete(null));
             closed.get(5, TimeUnit.SECONDS);
-            Thread.sleep(100);
 
+            long deadline = System.currentTimeMillis() + 5000;
+            while (gauge.value() > before && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50);
+            }
             Assertions.assertTrue(gauge.value() <= before,
                     "Gauge should decrease when a connection is closed");
         } finally {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
@@ -1,0 +1,84 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonObject;
+
+public class MetricsJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    MeterRegistry registry;
+
+    @TestHTTPResource("json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testRequestMetricsRecorded() throws Exception {
+        callJsonRpc("HelloResource#hello", 1);
+        callJsonRpc("HelloResource#hello", 2);
+
+        Timer successTimer = registry.find("jsonrpc.requests")
+                .tag("method", "HelloResource#hello")
+                .tag("outcome", "success")
+                .timer();
+        Assertions.assertNotNull(successTimer, "Expected jsonrpc.requests timer to be registered");
+        Assertions.assertEquals(2, successTimer.count());
+        Assertions.assertTrue(successTimer.totalTime(TimeUnit.NANOSECONDS) > 0);
+    }
+
+    @Test
+    public void testConnectionGauge() throws Exception {
+        callJsonRpc("HelloResource#hello", 3);
+
+        Assertions.assertNotNull(
+                registry.find("jsonrpc.active.connections").gauge(),
+                "Expected jsonrpc.active.connections gauge to be registered");
+    }
+
+    private void callJsonRpc(String method, int id) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(
+                                    JsonObject.of("jsonrpc", "2.0", "id", id, "method", method).encode());
+                        } else {
+                            messages.add(JsonObject.of("error",
+                                    JsonObject.of("message", r.cause().getMessage())).encode());
+                        }
+                    });
+            String response = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received");
+            JsonObject json = new JsonObject(response);
+            Assertions.assertNull(json.getJsonObject("error"), "Unexpected error: " + response);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
@@ -10,12 +13,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.quarkiverse.jsonrpc.app.FailingResource;
 import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkiverse.jsonrpc.app.MultiResource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.json.JsonObject;
 
@@ -23,7 +31,8 @@ public class MetricsJsonRpcTest {
 
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
+            .withApplicationRoot(root -> root.addClasses(
+                    HelloResource.class, FailingResource.class, MultiResource.class));
 
     @Inject
     Vertx vertx;
@@ -49,12 +58,147 @@ public class MetricsJsonRpcTest {
     }
 
     @Test
-    public void testConnectionGauge() throws Exception {
-        callJsonRpc("HelloResource#hello", 3);
+    public void testErrorMetricsRecorded() throws Exception {
+        callJsonRpcExpectError("FailingResource#fail", 10);
 
-        Assertions.assertNotNull(
-                registry.find("jsonrpc.active.connections").gauge(),
-                "Expected jsonrpc.active.connections gauge to be registered");
+        Timer errorTimer = registry.find("jsonrpc.requests")
+                .tag("method", "FailingResource#fail")
+                .tag("outcome", "error")
+                .timer();
+        Assertions.assertNotNull(errorTimer, "Expected jsonrpc.requests error timer to be registered");
+        Assertions.assertEquals(1, errorTimer.count());
+    }
+
+    @Test
+    public void testConnectionGauge() throws Exception {
+        Gauge gauge = registry.find("jsonrpc.active.connections").gauge();
+        Assertions.assertNotNull(gauge, "Expected jsonrpc.active.connections gauge to be registered");
+
+        double before = gauge.value();
+        CompletableFuture<WebSocket> connected = new CompletableFuture<>();
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            connected.complete(r.result());
+                        } else {
+                            connected.completeExceptionally(r.cause());
+                        }
+                    });
+            WebSocket ws = connected.get(5, TimeUnit.SECONDS);
+
+            Assertions.assertTrue(gauge.value() > before,
+                    "Gauge should increase when a connection is opened");
+
+            CompletableFuture<Void> closed = new CompletableFuture<>();
+            ws.close().onComplete(r -> closed.complete(null));
+            closed.get(5, TimeUnit.SECONDS);
+            Thread.sleep(100);
+
+            Assertions.assertTrue(gauge.value() <= before,
+                    "Gauge should decrease when a connection is closed");
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    @Test
+    public void testMultiInvocationMetrics() throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            CompletableFuture<Void> connected = new CompletableFuture<>();
+            JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 20, "method", "MultiResource#items");
+
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(request.encode());
+                            connected.complete(null);
+                        } else {
+                            connected.completeExceptionally(r.cause());
+                        }
+                    });
+
+            connected.get(5, TimeUnit.SECONDS);
+
+            // Ack
+            String ackMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(ackMsg, "Expected ack message");
+            JsonObject ack = new JsonObject(ackMsg);
+            Assertions.assertNotNull(ack.getString("result"), "Ack should contain subscription ID");
+
+            // Drain items + completion
+            List<String> received = new ArrayList<>();
+            for (int i = 0; i < 4; i++) {
+                String msg = messages.poll(10, TimeUnit.SECONDS);
+                Assertions.assertNotNull(msg, "Expected message " + i);
+                received.add(msg);
+            }
+
+            Timer successTimer = registry.find("jsonrpc.requests")
+                    .tag("method", "MultiResource#items")
+                    .tag("outcome", "success")
+                    .timer();
+            Assertions.assertNotNull(successTimer,
+                    "Expected jsonrpc.requests success timer for Multi method");
+            Assertions.assertTrue(successTimer.count() > 0);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    @Test
+    public void testMultiSubscriptionErrorMetrics() throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            CompletableFuture<Void> connected = new CompletableFuture<>();
+            JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 30, "method", "MultiResource#failing");
+
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(request.encode());
+                            connected.complete(null);
+                        } else {
+                            connected.completeExceptionally(r.cause());
+                        }
+                    });
+
+            connected.get(5, TimeUnit.SECONDS);
+
+            // Ack
+            String ackMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(ackMsg, "Expected ack message");
+
+            // Error notification
+            String errMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(errMsg, "Expected error notification");
+            JsonObject errJson = new JsonObject(errMsg);
+            Assertions.assertNotNull(errJson.getJsonObject("params").getJsonObject("error"),
+                    "Expected error in notification params");
+
+            Counter errorCounter = registry.find("jsonrpc.subscription.errors")
+                    .tag("method", "MultiResource#failing")
+                    .counter();
+            Assertions.assertNotNull(errorCounter,
+                    "Expected jsonrpc.subscription.errors counter for failing Multi");
+            Assertions.assertTrue(errorCounter.count() > 0);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    @Test
+    public void testSubscriptionsActiveGauge() throws Exception {
+        Gauge gauge = registry.find("jsonrpc.subscriptions.active").gauge();
+        Assertions.assertNotNull(gauge, "Expected jsonrpc.subscriptions.active gauge to be registered");
     }
 
     private void callJsonRpc(String method, int id) throws Exception {
@@ -77,6 +221,31 @@ public class MetricsJsonRpcTest {
             Assertions.assertNotNull(response, "No response received");
             JsonObject json = new JsonObject(response);
             Assertions.assertNull(json.getJsonObject("error"), "Unexpected error: " + response);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private void callJsonRpcExpectError(String method, int id) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(
+                                    JsonObject.of("jsonrpc", "2.0", "id", id, "method", method).encode());
+                        } else {
+                            messages.add(JsonObject.of("error",
+                                    JsonObject.of("message", r.cause().getMessage())).encode());
+                        }
+                    });
+            String response = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received");
+            JsonObject json = new JsonObject(response);
+            Assertions.assertNotNull(json.getJsonObject("error"), "Expected an error response");
         } finally {
             client.close().toCompletionStage().toCompletableFuture().get();
         }

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 ** xref:guides-broadcasting.adoc[Broadcasting]
 ** xref:guides-security.adoc[Security]
 ** xref:guides-concurrency.adoc[Concurrency & Session Isolation]
+** xref:guides-metrics.adoc[Metrics]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 
 .Reference

--- a/docs/modules/ROOT/pages/guides-metrics.adoc
+++ b/docs/modules/ROOT/pages/guides-metrics.adoc
@@ -1,0 +1,44 @@
+= Metrics
+
+include::./includes/attributes.adoc[]
+
+When the `quarkus-micrometer` extension is present, JSON-RPC automatically records metrics for every method invocation and tracks active WebSocket connections. No configuration or code changes are needed.
+
+== Setup
+
+Add the Micrometer extension (with a registry of your choice):
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+</dependency>
+----
+
+That's it — metrics are enabled automatically.
+
+== Available Metrics
+
+[cols="1,1,2"]
+|===
+| Metric | Type | Description
+
+| `jsonrpc.requests`
+| Timer
+| Duration and count of JSON-RPC method invocations. Tagged with `method` (e.g. `HelloResource#hello`) and `outcome` (`success` or `error`).
+
+| `jsonrpc.active.connections`
+| Gauge
+| Current number of open WebSocket connections.
+|===
+
+== Example: Prometheus Output
+
+After calling `HelloResource#hello` a few times, the Prometheus endpoint (`/q/metrics`) will include:
+
+----
+jsonrpc_requests_seconds_count{method="HelloResource#hello",outcome="success"} 5.0
+jsonrpc_requests_seconds_sum{method="HelloResource#hello",outcome="success"} 0.042
+jsonrpc_active_connections 2.0
+----

--- a/docs/modules/ROOT/pages/guides-metrics.adoc
+++ b/docs/modules/ROOT/pages/guides-metrics.adoc
@@ -2,7 +2,7 @@
 
 include::./includes/attributes.adoc[]
 
-When the `quarkus-micrometer` extension is present, JSON-RPC automatically records metrics for every method invocation and tracks active WebSocket connections. No configuration or code changes are needed.
+When the `quarkus-micrometer` extension is present, JSON-RPC automatically records metrics for every method invocation and tracks active WebSocket connections and streaming subscriptions. No configuration or code changes are needed.
 
 == Setup
 
@@ -26,19 +26,29 @@ That's it — metrics are enabled automatically.
 
 | `jsonrpc.requests`
 | Timer
-| Duration and count of JSON-RPC method invocations. Tagged with `method` (e.g. `HelloResource#hello`) and `outcome` (`success` or `error`).
+| Duration and count of JSON-RPC method invocations. Tagged with `method` (e.g. `HelloResource#hello`) and `outcome` (`success` or `error`). For streaming methods (`Multi`/`Flow.Publisher`), this measures the time to create the stream — not the total streaming duration.
 
 | `jsonrpc.active.connections`
 | Gauge
 | Current number of open WebSocket connections.
+
+| `jsonrpc.subscriptions.active`
+| Gauge
+| Current number of active streaming subscriptions (`Multi`/`Flow.Publisher`).
+
+| `jsonrpc.subscription.errors`
+| Counter
+| Number of errors that occurred during active streaming subscriptions. Tagged with `method`.
 |===
 
 == Example: Prometheus Output
 
-After calling `HelloResource#hello` a few times, the Prometheus endpoint (`/q/metrics`) will include:
+After calling `HelloResource#hello` a few times and subscribing to a streaming method, the Prometheus endpoint (`/q/metrics`) will include:
 
 ----
 jsonrpc_requests_seconds_count{method="HelloResource#hello",outcome="success"} 5.0
 jsonrpc_requests_seconds_sum{method="HelloResource#hello",outcome="success"} 0.042
 jsonrpc_active_connections 2.0
+jsonrpc_subscriptions_active 1.0
+jsonrpc_subscription_errors_total{method="MultiResource#failing"} 0.0
 ----

--- a/docs/modules/ROOT/pages/guides-metrics.adoc
+++ b/docs/modules/ROOT/pages/guides-metrics.adoc
@@ -26,7 +26,7 @@ That's it — metrics are enabled automatically.
 
 | `jsonrpc.requests`
 | Timer
-| Duration and count of JSON-RPC method invocations. Tagged with `method` (e.g. `HelloResource#hello`) and `outcome` (`success` or `error`). For streaming methods (`Multi`/`Flow.Publisher`), this measures the time to create the stream — not the total streaming duration.
+| Duration and count of JSON-RPC method invocations. Tagged with `method` (e.g. `HelloResource#hello`) and `outcome` (`success` or `error`). For streaming methods (`Multi`/`Flow.Publisher`), this measures the time to create the stream — not the total streaming duration. A streaming method that creates the `Multi` successfully records `outcome=success` even if the subscription later fails; subscription-level errors are tracked separately by `jsonrpc.subscription.errors`.
 
 | `jsonrpc.active.connections`
 | Gauge

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -109,6 +109,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 | xref:guides-concurrency.adoc[Concurrency & Session Isolation]
 | Connection isolation, shared bean instances, threading model, and tuning for production.
 
+| xref:guides-metrics.adoc[Metrics]
+| Automatic request timing and connection tracking with Micrometer.
+
 | xref:guides-javascript-client.adoc[JavaScript Client]
 | Generate a typed JavaScript proxy for calling your endpoints from the browser.
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>quarkus-virtual-threads</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetrics.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetrics.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+public class JsonRPCMetrics {
+
+    private final MeterRegistry registry;
+    private final ConcurrentHashMap<String, Timer> successTimers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Timer> errorTimers = new ConcurrentHashMap<>();
+    private final AtomicLong activeConnections = new AtomicLong(0);
+
+    JsonRPCMetrics(MeterRegistry registry) {
+        this.registry = registry;
+        io.micrometer.core.instrument.Gauge.builder("jsonrpc.active.connections", activeConnections, AtomicLong::doubleValue)
+                .description("Current number of active JSON-RPC WebSocket connections")
+                .register(registry);
+    }
+
+    void recordSuccess(String method, long durationNanos) {
+        getTimer(method, "success", successTimers).record(durationNanos, TimeUnit.NANOSECONDS);
+    }
+
+    void recordError(String method, long durationNanos) {
+        getTimer(method, "error", errorTimers).record(durationNanos, TimeUnit.NANOSECONDS);
+    }
+
+    void connectionOpened() {
+        activeConnections.incrementAndGet();
+    }
+
+    void connectionClosed() {
+        activeConnections.decrementAndGet();
+    }
+
+    private Timer getTimer(String method, String outcome, ConcurrentHashMap<String, Timer> cache) {
+        return cache.computeIfAbsent(method, m -> Timer.builder("jsonrpc.requests")
+                .description("JSON-RPC method invocation duration and count")
+                .tag("method", m)
+                .tag("outcome", outcome)
+                .register(registry));
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetrics.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetrics.java
@@ -12,12 +12,16 @@ import io.quarkus.arc.Arc;
 
 class JsonRPCMetrics implements JsonRPCMetricsHandler {
 
+    // Gauge state objects are static so the MeterRegistry's existing gauge references
+    // remain valid across hot reloads (Micrometer returns the old gauge on duplicate
+    // registration, so new AtomicLongs would never be observed).
+    private static final AtomicLong activeConnections = new AtomicLong(0);
+    private static final AtomicLong activeSubscriptions = new AtomicLong(0);
+
     private final MeterRegistry registry;
     private final ConcurrentHashMap<String, Timer> successTimers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Timer> errorTimers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Counter> subscriptionErrorCounters = new ConcurrentHashMap<>();
-    private final AtomicLong activeConnections = new AtomicLong(0);
-    private final AtomicLong activeSubscriptions = new AtomicLong(0);
 
     private JsonRPCMetrics(MeterRegistry registry) {
         this.registry = registry;
@@ -30,6 +34,8 @@ class JsonRPCMetrics implements JsonRPCMetricsHandler {
     }
 
     static JsonRPCMetrics create() {
+        activeConnections.set(0);
+        activeSubscriptions.set(0);
         MeterRegistry registry = Arc.container().select(MeterRegistry.class).get();
         return new JsonRPCMetrics(registry);
     }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetrics.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetrics.java
@@ -4,37 +4,73 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.arc.Arc;
 
-public class JsonRPCMetrics {
+class JsonRPCMetrics implements JsonRPCMetricsHandler {
 
     private final MeterRegistry registry;
     private final ConcurrentHashMap<String, Timer> successTimers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Timer> errorTimers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> subscriptionErrorCounters = new ConcurrentHashMap<>();
     private final AtomicLong activeConnections = new AtomicLong(0);
+    private final AtomicLong activeSubscriptions = new AtomicLong(0);
 
-    JsonRPCMetrics(MeterRegistry registry) {
+    private JsonRPCMetrics(MeterRegistry registry) {
         this.registry = registry;
-        io.micrometer.core.instrument.Gauge.builder("jsonrpc.active.connections", activeConnections, AtomicLong::doubleValue)
+        Gauge.builder("jsonrpc.active.connections", activeConnections, AtomicLong::doubleValue)
                 .description("Current number of active JSON-RPC WebSocket connections")
+                .register(registry);
+        Gauge.builder("jsonrpc.subscriptions.active", activeSubscriptions, AtomicLong::doubleValue)
+                .description("Current number of active JSON-RPC streaming subscriptions")
                 .register(registry);
     }
 
-    void recordSuccess(String method, long durationNanos) {
+    static JsonRPCMetrics create() {
+        MeterRegistry registry = Arc.container().select(MeterRegistry.class).get();
+        return new JsonRPCMetrics(registry);
+    }
+
+    @Override
+    public void recordSuccess(String method, long durationNanos) {
         getTimer(method, "success", successTimers).record(durationNanos, TimeUnit.NANOSECONDS);
     }
 
-    void recordError(String method, long durationNanos) {
+    @Override
+    public void recordError(String method, long durationNanos) {
         getTimer(method, "error", errorTimers).record(durationNanos, TimeUnit.NANOSECONDS);
     }
 
-    void connectionOpened() {
+    @Override
+    public void connectionOpened() {
         activeConnections.incrementAndGet();
     }
 
-    void connectionClosed() {
-        activeConnections.decrementAndGet();
+    @Override
+    public void connectionClosed() {
+        activeConnections.updateAndGet(v -> Math.max(0, v - 1));
+    }
+
+    @Override
+    public void subscriptionStarted() {
+        activeSubscriptions.incrementAndGet();
+    }
+
+    @Override
+    public void subscriptionEnded() {
+        activeSubscriptions.updateAndGet(v -> Math.max(0, v - 1));
+    }
+
+    @Override
+    public void recordSubscriptionError(String method) {
+        subscriptionErrorCounters.computeIfAbsent(method, m -> Counter.builder("jsonrpc.subscription.errors")
+                .description("Number of errors during active JSON-RPC streaming subscriptions")
+                .tag("method", m)
+                .register(registry))
+                .increment();
     }
 
     private Timer getTimer(String method, String outcome, ConcurrentHashMap<String, Timer> cache) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetricsHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCMetricsHandler.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+interface JsonRPCMetricsHandler {
+
+    void recordSuccess(String method, long durationNanos);
+
+    void recordError(String method, long durationNanos);
+
+    void connectionOpened();
+
+    void connectionClosed();
+
+    void subscriptionStarted();
+
+    void subscriptionEnded();
+
+    void recordSubscriptionError(String method);
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -25,6 +25,10 @@ public class JsonRPCRecorder {
         metrics = JsonRPCMetrics.create();
     }
 
+    public void clearMetrics() {
+        metrics = null;
+    }
+
     public Supplier<JsonRPCSessions> createJsonRpcSessions() {
         return JsonRPCSessions::new;
     }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -6,10 +6,12 @@ import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkiverse.jsonrpc.api.JsonRPCBroadcaster;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
+import io.quarkus.arc.Arc;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
@@ -18,6 +20,14 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class JsonRPCRecorder {
+
+    // package-private for use by JsonRPCRouter; visible for testing
+    public static volatile JsonRPCMetrics metrics;
+
+    public void initMetrics() {
+        MeterRegistry registry = Arc.container().select(MeterRegistry.class).get();
+        metrics = new JsonRPCMetrics(registry);
+    }
 
     public Supplier<JsonRPCSessions> createJsonRpcSessions() {
         return JsonRPCSessions::new;

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -6,12 +6,10 @@ import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkiverse.jsonrpc.api.JsonRPCBroadcaster;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
-import io.quarkus.arc.Arc;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
@@ -21,12 +19,10 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class JsonRPCRecorder {
 
-    // package-private for use by JsonRPCRouter; visible for testing
-    public static volatile JsonRPCMetrics metrics;
+    static volatile JsonRPCMetricsHandler metrics;
 
     public void initMetrics() {
-        MeterRegistry registry = Arc.container().select(MeterRegistry.class).get();
-        metrics = new JsonRPCMetrics(registry);
+        metrics = JsonRPCMetrics.create();
     }
 
     public Supplier<JsonRPCSessions> createJsonRpcSessions() {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -68,6 +68,10 @@ public class JsonRPCRouter {
         populateJsonRPCMethods(methodsMap);
     }
 
+    private static JsonRPCMetrics metrics() {
+        return JsonRPCRecorder.metrics;
+    }
+
     /**
      * This gets called on build to build into of the classes we are going to call in runtime
      *
@@ -223,6 +227,10 @@ public class JsonRPCRouter {
 
     public void addSocket(ServerWebSocket socket, SecurityIdentity identity) {
         sessions.addSession(socket);
+        JsonRPCMetrics m = metrics();
+        if (m != null) {
+            m.connectionOpened();
+        }
         if (identity != null && !identity.isAnonymous()) {
             socketIdentities.put(socket, identity);
         }
@@ -233,6 +241,10 @@ public class JsonRPCRouter {
         socket.closeHandler((e) -> {
             sessions.removeSession(socket);
             socketIdentities.remove(socket);
+            JsonRPCMetrics mc = metrics();
+            if (mc != null) {
+                mc.connectionClosed();
+            }
             Map<String, Cancellable> subs = socketSubscriptions.remove(socket);
             if (subs != null) {
                 for (Map.Entry<String, Cancellable> entry : subs.entrySet()) {
@@ -281,6 +293,9 @@ public class JsonRPCRouter {
         if (this.jsonRpcToJava.containsKey(key)) {
             ReflectionInfo reflectionInfo = this.jsonRpcToJava.get(key);
             Object target = Arc.container().select(reflectionInfo.bean).get();
+            String methodName = jsonRpcRequest.getMethod();
+            JsonRPCMetrics m = metrics();
+            long startNanos = m != null ? System.nanoTime() : 0;
 
             if (reflectionInfo.isReturningMulti() || reflectionInfo.isReturningFlowPublisher()) {
                 Multi<?> multi;
@@ -306,9 +321,12 @@ public class JsonRPCRouter {
                         multi = Multi.createFrom().publisher((Flow.Publisher<?>) result);
                     }
                 } catch (Exception e) {
-                    LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", jsonRpcRequest.getMethod(),
+                    if (m != null) {
+                        m.recordError(methodName, System.nanoTime() - startNanos);
+                    }
+                    LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", methodName,
                             jsonRpcRequest);
-                    codec.writeErrorResponse(s, jsonRpcRequest.getId(), jsonRpcRequest.getMethod(), unwrap(e));
+                    codec.writeErrorResponse(s, jsonRpcRequest.getId(), methodName, unwrap(e));
                     return;
                 } finally {
                     if (activated) {
@@ -316,8 +334,11 @@ public class JsonRPCRouter {
                     }
                 }
 
+                if (m != null) {
+                    m.recordSuccess(methodName, System.nanoTime() - startNanos);
+                }
+
                 String subscriptionId = UUID.randomUUID().toString();
-                String methodName = jsonRpcRequest.getMethod();
                 Map<String, Cancellable> subs = this.socketSubscriptions.computeIfAbsent(s,
                         k -> new ConcurrentHashMap<>());
 
@@ -354,16 +375,25 @@ public class JsonRPCRouter {
                         uni = invoke(reflectionInfo, target, new Object[0], s);
                     }
                 } catch (Exception e) {
-                    LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", jsonRpcRequest.getMethod(),
+                    if (m != null) {
+                        m.recordError(methodName, System.nanoTime() - startNanos);
+                    }
+                    LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", methodName,
                             jsonRpcRequest);
-                    codec.writeErrorResponse(s, jsonRpcRequest.getId(), jsonRpcRequest.getMethod(), unwrap(e));
+                    codec.writeErrorResponse(s, jsonRpcRequest.getId(), methodName, unwrap(e));
                     return;
                 }
                 uni.subscribe()
                         .with(item -> {
+                            if (m != null) {
+                                m.recordSuccess(methodName, System.nanoTime() - startNanos);
+                            }
                             codec.writeResponse(s, jsonRpcRequest.getId(), item);
                         }, failure -> {
-                            codec.writeErrorResponse(s, jsonRpcRequest.getId(), jsonRpcRequest.getMethod(), unwrap(failure));
+                            if (m != null) {
+                                m.recordError(methodName, System.nanoTime() - startNanos);
+                            }
+                            codec.writeErrorResponse(s, jsonRpcRequest.getId(), methodName, unwrap(failure));
                         });
             }
         } else {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -68,7 +68,7 @@ public class JsonRPCRouter {
         populateJsonRPCMethods(methodsMap);
     }
 
-    private static JsonRPCMetrics metrics() {
+    private static JsonRPCMetricsHandler metrics() {
         return JsonRPCRecorder.metrics;
     }
 
@@ -227,7 +227,7 @@ public class JsonRPCRouter {
 
     public void addSocket(ServerWebSocket socket, SecurityIdentity identity) {
         sessions.addSession(socket);
-        JsonRPCMetrics m = metrics();
+        JsonRPCMetricsHandler m = metrics();
         if (m != null) {
             m.connectionOpened();
         }
@@ -241,17 +241,21 @@ public class JsonRPCRouter {
         socket.closeHandler((e) -> {
             sessions.removeSession(socket);
             socketIdentities.remove(socket);
-            JsonRPCMetrics mc = metrics();
+            JsonRPCMetricsHandler mc = metrics();
             if (mc != null) {
                 mc.connectionClosed();
             }
             Map<String, Cancellable> subs = socketSubscriptions.remove(socket);
             if (subs != null) {
+                JsonRPCMetricsHandler ms = metrics();
                 for (Map.Entry<String, Cancellable> entry : subs.entrySet()) {
                     try {
                         entry.getValue().cancel();
                     } catch (Exception ex) {
                         LOG.warnf(ex, "Failed to cancel subscription %s on WebSocket close", entry.getKey());
+                    }
+                    if (ms != null) {
+                        ms.subscriptionEnded();
                     }
                 }
             }
@@ -294,7 +298,7 @@ public class JsonRPCRouter {
             ReflectionInfo reflectionInfo = this.jsonRpcToJava.get(key);
             Object target = Arc.container().select(reflectionInfo.bean).get();
             String methodName = jsonRpcRequest.getMethod();
-            JsonRPCMetrics m = metrics();
+            JsonRPCMetricsHandler m = metrics();
             long startNanos = m != null ? System.nanoTime() : 0;
 
             if (reflectionInfo.isReturningMulti() || reflectionInfo.isReturningFlowPublisher()) {
@@ -351,14 +355,25 @@ public class JsonRPCRouter {
                 // Send ack before subscribing so client has subscription ID before items arrive
                 codec.writeResponse(s, jsonRpcRequest.getId(), subscriptionId);
 
+                if (m != null) {
+                    m.subscriptionStarted();
+                }
+
                 Cancellable cancellable = multi.subscribe()
                         .with(
                                 item -> codec.writeSubscriptionItem(s, subscriptionId, item),
                                 failure -> {
+                                    if (m != null) {
+                                        m.recordSubscriptionError(methodName);
+                                        m.subscriptionEnded();
+                                    }
                                     codec.writeSubscriptionError(s, subscriptionId, methodName, unwrap(failure));
                                     subs.remove(subscriptionId);
                                 },
                                 () -> {
+                                    if (m != null) {
+                                        m.subscriptionEnded();
+                                    }
                                     codec.writeSubscriptionComplete(s, subscriptionId);
                                     subs.remove(subscriptionId);
                                 });
@@ -424,6 +439,10 @@ public class JsonRPCRouter {
             Cancellable cancellable = subs.remove(subscriptionId);
             if (cancellable != null) {
                 cancellable.cancel();
+                JsonRPCMetricsHandler m = metrics();
+                if (m != null) {
+                    m.subscriptionEnded();
+                }
                 codec.writeResponse(s, jsonRpcRequest.getId(), true);
                 return;
             }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -247,15 +247,14 @@ public class JsonRPCRouter {
             }
             Map<String, Cancellable> subs = socketSubscriptions.remove(socket);
             if (subs != null) {
-                JsonRPCMetricsHandler ms = metrics();
                 for (Map.Entry<String, Cancellable> entry : subs.entrySet()) {
                     try {
                         entry.getValue().cancel();
                     } catch (Exception ex) {
                         LOG.warnf(ex, "Failed to cancel subscription %s on WebSocket close", entry.getKey());
                     }
-                    if (ms != null) {
-                        ms.subscriptionEnded();
+                    if (mc != null) {
+                        mc.subscriptionEnded();
                     }
                 }
             }


### PR DESCRIPTION
When `quarkus-micrometer` is on the classpath, the extension now automatically records metrics for every JSON-RPC method invocation — no configuration or code changes needed.

Micrometer is an optional dependency — when absent, the metrics code path is completely skipped with zero overhead. The router references only a package-private `JsonRPCMetricsHandler` interface that has no Micrometer imports, so the optional dependency is safe for native image builds.

Four metrics are recorded:

- **`jsonrpc.requests`** (Timer) — duration and count per method, tagged with `method` and `outcome` (success/error). For streaming methods (`Multi`/`Flow.Publisher`), this measures the time to create the stream, not total streaming duration
- **`jsonrpc.active.connections`** (Gauge) — current number of open WebSocket connections
- **`jsonrpc.subscriptions.active`** (Gauge) — current number of active streaming subscriptions, decremented on completion, error, explicit unsubscribe, or WebSocket close
- **`jsonrpc.subscription.errors`** (Counter) — number of errors during active streaming subscriptions, tagged with `method`

Gauge state uses `static AtomicLong` fields so the values survive Micrometer's meter deduplication (which discards duplicate gauge registrations but keeps the first supplier reference). Metrics are properly cleared on hot reload via a `ShutdownContext` callback.

Fixes #78