### PR TITLE
Remove dead guides link

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,7 +8,6 @@ metadata:
     - jsonrpc
     - websocket
     - rpc
-  guide: https://quarkiverse.github.io/quarkiverse-docs/json-rpc/dev/
   categories:
     - "web"
   status: "preview"


### PR DESCRIPTION
The docs in this repo looked thin, so I made the guess they weren't worth publishing. If you do want to publish instead of removing the link, instructions are in hub.quarkiverse.io.