### PR TITLE
Fix guide URL in extension metadata

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,7 +8,7 @@ metadata:
     - jsonrpc
     - websocket
     - rpc
-  guide: https://quarkiverse.github.io/quarkiverse-docs/json-rpc/dev/
+  guide: https://docs.quarkiverse.io/quarkus-json-rpc/dev/
   categories:
     - "web"
   status: "preview"


### PR DESCRIPTION
The guide link in `quarkus-extension.yaml` pointed to the old `quarkiverse.github.io/quarkiverse-docs/json-rpc/dev/` path which returns a 404. The docs are published at `docs.quarkiverse.io/quarkus-json-rpc/dev/` — this updates the URL to match.

Supersedes #124 — the docs are comprehensive, just the link was wrong.