### PR TITLE
Support batch requests per JSON-RPC 2.0 spec

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/BatchJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/BatchJsonRpcTest.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
@@ -11,9 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkiverse.jsonrpc.app.MultiResource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -23,7 +28,7 @@ public class BatchJsonRpcTest {
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
-                root.addClasses(HelloResource.class);
+                root.addClasses(HelloResource.class, MultiResource.class);
             });
 
     @Inject
@@ -118,6 +123,118 @@ public class BatchJsonRpcTest {
         JsonObject response = new JsonObject(rawResponse);
         Assertions.assertNotNull(response.getJsonObject("error"));
         Assertions.assertEquals(-32700, response.getJsonObject("error").getInteger("code"));
+    }
+
+    @Test
+    public void testBatchWithMultiStreaming() throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            CompletableFuture<WebSocket> connected = new CompletableFuture<>();
+
+            JsonArray batch = new JsonArray()
+                    .add(JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello"))
+                    .add(JsonObject.of("jsonrpc", "2.0", "id", 2, "method", "MultiResource#items"));
+
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(batch.encode());
+                            connected.complete(ws);
+                        } else {
+                            connected.completeExceptionally(r.cause());
+                        }
+                    });
+
+            connected.get(5, TimeUnit.SECONDS);
+
+            // First message: the batch response array containing both results
+            String batchMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(batchMsg, "Expected batch response");
+            JsonArray responses = new JsonArray(batchMsg);
+            Assertions.assertEquals(2, responses.size());
+
+            JsonObject r1 = findById(responses, 1);
+            Assertions.assertNotNull(r1, "Response with id=1 not found");
+            Assertions.assertTrue(r1.getString("result").startsWith("Hello ["));
+
+            JsonObject r2 = findById(responses, 2);
+            Assertions.assertNotNull(r2, "Response with id=2 not found");
+            String subscriptionId = r2.getString("result");
+            Assertions.assertNotNull(subscriptionId, "Multi ack should contain a subscription ID");
+
+            // Subsequent messages: subscription item notifications delivered individually
+            List<String> items = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                String msg = messages.poll(10, TimeUnit.SECONDS);
+                Assertions.assertNotNull(msg, "Expected item notification " + i);
+                JsonObject json = new JsonObject(msg);
+                Assertions.assertEquals("2.0", json.getString("jsonrpc"));
+                Assertions.assertFalse(json.containsKey("id"), "Notification must not have an id");
+                Assertions.assertEquals("subscription", json.getString("method"));
+                JsonObject params = json.getJsonObject("params");
+                Assertions.assertEquals(subscriptionId, params.getString("subscription"));
+                items.add(params.getString("result"));
+            }
+            Assertions.assertEquals(List.of("item-0", "item-1", "item-2"), items);
+
+            // Completion notification
+            String completeMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(completeMsg, "Expected completion notification");
+            JsonObject complete = new JsonObject(completeMsg);
+            Assertions.assertEquals("subscription", complete.getString("method"));
+            JsonObject completeParams = complete.getJsonObject("params");
+            Assertions.assertEquals(subscriptionId, completeParams.getString("subscription"));
+            Assertions.assertTrue(completeParams.getBoolean("complete"));
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    @Test
+    public void testBatchWithInvalidElement() throws Exception {
+        // A batch where one element is a bare number (valid JSON but not a valid JSON-RPC request)
+        String rawBatch = "[42, {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"HelloResource#hello\"}]";
+
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(rawBatch);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            String response = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+
+            JsonArray responses = new JsonArray(response);
+            Assertions.assertEquals(2, responses.size());
+
+            // One response should be an error for the invalid element
+            boolean hasInvalidRequestError = false;
+            boolean hasSuccessResult = false;
+            for (int i = 0; i < responses.size(); i++) {
+                JsonObject obj = responses.getJsonObject(i);
+                if (obj.getJsonObject("error") != null
+                        && obj.getJsonObject("error").getInteger("code") == -32600) {
+                    hasInvalidRequestError = true;
+                }
+                if (obj.getString("result") != null
+                        && obj.getString("result").startsWith("Hello [")) {
+                    hasSuccessResult = true;
+                }
+            }
+            Assertions.assertTrue(hasInvalidRequestError, "Expected an invalid request error for the bare number");
+            Assertions.assertTrue(hasSuccessResult, "Expected a success result for the valid request");
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
     }
 
     private JsonArray sendBatch(JsonArray batch) throws Exception {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/BatchJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/BatchJsonRpcTest.java
@@ -1,0 +1,158 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class BatchJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testBatchRequest() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello"))
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 2, "method", "HelloResource#helloNonBlocking"));
+
+        JsonArray responses = sendBatch(batch);
+
+        Assertions.assertEquals(2, responses.size());
+
+        JsonObject r1 = findById(responses, 1);
+        Assertions.assertNotNull(r1, "Response with id=1 not found");
+        Assertions.assertTrue(r1.getString("result").startsWith("Hello [executor-thread-"));
+
+        JsonObject r2 = findById(responses, 2);
+        Assertions.assertNotNull(r2, "Response with id=2 not found");
+        Assertions.assertTrue(r2.getString("result").startsWith("Hello [vert.x-eventloop-thread-"));
+    }
+
+    @Test
+    public void testBatchWithParams() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello",
+                        "params", JsonObject.of("name", "Alice")))
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 2, "method", "HelloResource#hello",
+                        "params", JsonObject.of("name", "Bob")));
+
+        JsonArray responses = sendBatch(batch);
+
+        Assertions.assertEquals(2, responses.size());
+
+        JsonObject r1 = findById(responses, 1);
+        Assertions.assertTrue(r1.getString("result").startsWith("Hello Alice ["));
+
+        JsonObject r2 = findById(responses, 2);
+        Assertions.assertTrue(r2.getString("result").startsWith("Hello Bob ["));
+    }
+
+    @Test
+    public void testBatchWithMethodNotFound() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello"))
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 2, "method", "NoSuchService#missing"));
+
+        JsonArray responses = sendBatch(batch);
+
+        Assertions.assertEquals(2, responses.size());
+
+        JsonObject r1 = findById(responses, 1);
+        Assertions.assertNotNull(r1.getString("result"));
+        Assertions.assertNull(r1.getJsonObject("error"));
+
+        JsonObject r2 = findById(responses, 2);
+        Assertions.assertNull(r2.getString("result"));
+        JsonObject error = r2.getJsonObject("error");
+        Assertions.assertNotNull(error);
+        Assertions.assertEquals(-32601, error.getInteger("code"));
+    }
+
+    @Test
+    public void testSingleElementBatch() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello"));
+
+        JsonArray responses = sendBatch(batch);
+
+        Assertions.assertEquals(1, responses.size());
+        JsonObject r1 = responses.getJsonObject(0);
+        Assertions.assertEquals(1, r1.getInteger("id"));
+        Assertions.assertTrue(r1.getString("result").startsWith("Hello ["));
+    }
+
+    @Test
+    public void testEmptyBatchReturnsError() throws Exception {
+        String rawResponse = sendRaw("[]");
+        JsonObject response = new JsonObject(rawResponse);
+        Assertions.assertNotNull(response.getJsonObject("error"));
+        Assertions.assertEquals(-32600, response.getJsonObject("error").getInteger("code"));
+    }
+
+    @Test
+    public void testMalformedJsonReturnsParseError() throws Exception {
+        String rawResponse = sendRaw("{not valid json");
+        JsonObject response = new JsonObject(rawResponse);
+        Assertions.assertNotNull(response.getJsonObject("error"));
+        Assertions.assertEquals(-32700, response.getJsonObject("error").getInteger("code"));
+    }
+
+    private JsonArray sendBatch(JsonArray batch) throws Exception {
+        String raw = sendRaw(batch.encode());
+        return new JsonArray(raw);
+    }
+
+    private String sendRaw(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            String response = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return response;
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private static JsonObject findById(JsonArray responses, int id) {
+        for (int i = 0; i < responses.size(); i++) {
+            JsonObject obj = responses.getJsonObject(i);
+            if (obj.getInteger("id") == id) {
+                return obj;
+            }
+        }
+        return null;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/MetricsJsonRpcTest.java
@@ -88,6 +88,10 @@ public class MetricsJsonRpcTest {
                     });
             WebSocket ws = connected.get(5, TimeUnit.SECONDS);
 
+            long openDeadline = System.currentTimeMillis() + 5000;
+            while (gauge.value() <= before && System.currentTimeMillis() < openDeadline) {
+                Thread.sleep(50);
+            }
             Assertions.assertTrue(gauge.value() > before,
                     "Gauge should increase when a connection is opened");
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -254,11 +254,11 @@ public class JsonRPCRouter {
                             new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request: empty batch")));
                     return;
                 }
-                List<JsonRPCRequest> requests = new ArrayList<>();
+                List<JsonNode> elements = new ArrayList<>();
                 for (JsonNode element : jsonNode) {
-                    requests.add(codec.readRequest(element));
+                    elements.add(element);
                 }
-                routeBatch(requests, socket);
+                routeBatch(elements, socket);
             } else {
                 JsonRPCRequest jsonRpcRequest = codec.readRequest(jsonNode);
                 route(jsonRpcRequest, socket);
@@ -311,11 +311,18 @@ public class JsonRPCRouter {
         }
     }
 
-    private void routeBatch(List<JsonRPCRequest> requests, ServerWebSocket s) {
+    private void routeBatch(List<JsonNode> elements, ServerWebSocket s) {
         Runnable dispatch = () -> {
             List<Uni<DispatchResult>> unis = new ArrayList<>();
-            for (JsonRPCRequest request : requests) {
-                unis.add(dispatchRoute(request, s));
+            for (JsonNode element : elements) {
+                if (!element.isObject() || !element.has(JsonRPCKeys.METHOD)) {
+                    int id = element.has(JsonRPCKeys.ID) ? element.get(JsonRPCKeys.ID).asInt(0) : 0;
+                    unis.add(Uni.createFrom().item(new DispatchResult(new JsonRPCResponse<>(id,
+                            new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request")))));
+                } else {
+                    JsonRPCRequest request = codec.readRequest(element);
+                    unis.add(dispatchRoute(request, s));
+                }
             }
             Uni.join().all(unis).andCollectFailures()
                     .subscribe().with(
@@ -331,7 +338,12 @@ public class JsonRPCRouter {
                                 codec.writeBatchResponse(s, responses);
                                 postWrites.forEach(Runnable::run);
                             },
-                            failure -> LOG.errorf(failure, "Unexpected error processing batch request"));
+                            failure -> {
+                                LOG.errorf(failure, "Unexpected error processing batch request");
+                                codec.writeResponse(s, new JsonRPCResponse<>(0,
+                                        new JsonRPCResponse.Error(JsonRPCKeys.INTERNAL_ERROR,
+                                                "Internal error processing batch")));
+                            });
         };
 
         if (JsonRPCHotReplacementSetup.isEnabled()) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -17,12 +17,16 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.logging.Logger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
 import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCKeys;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCRequest;
+import io.quarkiverse.jsonrpc.runtime.model.JsonRPCResponse;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
@@ -235,8 +239,30 @@ public class JsonRPCRouter {
             socketIdentities.put(socket, identity);
         }
         socket.textMessageHandler((e) -> {
-            JsonRPCRequest jsonRpcRequest = codec.readRequest(e);
-            route(jsonRpcRequest, socket);
+            JsonNode jsonNode;
+            try {
+                jsonNode = codec.parseJson(e);
+            } catch (JsonProcessingException ex) {
+                codec.writeResponse(socket,
+                        new JsonRPCResponse<>(0, new JsonRPCResponse.Error(JsonRPCKeys.PARSE_ERROR, "Parse error")));
+                return;
+            }
+
+            if (jsonNode.isArray()) {
+                if (jsonNode.isEmpty()) {
+                    codec.writeResponse(socket, new JsonRPCResponse<>(0,
+                            new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request: empty batch")));
+                    return;
+                }
+                List<JsonRPCRequest> requests = new ArrayList<>();
+                for (JsonNode element : jsonNode) {
+                    requests.add(codec.readRequest(element));
+                }
+                routeBatch(requests, socket);
+            } else {
+                JsonRPCRequest jsonRpcRequest = codec.readRequest(jsonNode);
+                route(jsonRpcRequest, socket);
+            }
         });
         socket.closeHandler((e) -> {
             sessions.removeSession(socket);
@@ -270,19 +296,76 @@ public class JsonRPCRouter {
                 if (ar.failed()) {
                     LOG.warnf(ar.cause(), "JSON-RPC hot reload scan failed");
                 }
-                dispatchRoute(jsonRpcRequest, s);
+                dispatchRoute(jsonRpcRequest, s)
+                        .subscribe().with(result -> {
+                            codec.writeResponse(s, result.response);
+                            result.runPostWrite();
+                        });
             });
         } else {
-            dispatchRoute(jsonRpcRequest, s);
+            dispatchRoute(jsonRpcRequest, s)
+                    .subscribe().with(result -> {
+                        codec.writeResponse(s, result.response);
+                        result.runPostWrite();
+                    });
+        }
+    }
+
+    private void routeBatch(List<JsonRPCRequest> requests, ServerWebSocket s) {
+        Runnable dispatch = () -> {
+            List<Uni<DispatchResult>> unis = new ArrayList<>();
+            for (JsonRPCRequest request : requests) {
+                unis.add(dispatchRoute(request, s));
+            }
+            Uni.join().all(unis).andCollectFailures()
+                    .subscribe().with(
+                            results -> {
+                                List<JsonRPCResponse<?>> responses = new ArrayList<>();
+                                List<Runnable> postWrites = new ArrayList<>();
+                                for (DispatchResult result : results) {
+                                    responses.add(result.response);
+                                    if (result.postWrite != null) {
+                                        postWrites.add(result.postWrite);
+                                    }
+                                }
+                                codec.writeBatchResponse(s, responses);
+                                postWrites.forEach(Runnable::run);
+                            },
+                            failure -> LOG.errorf(failure, "Unexpected error processing batch request"));
+        };
+
+        if (JsonRPCHotReplacementSetup.isEnabled()) {
+            Vertx.currentContext().<Void> executeBlocking(() -> {
+                JsonRPCHotReplacementSetup.scan();
+                return null;
+            }).onComplete(ar -> {
+                if (ar.failed()) {
+                    LOG.warnf(ar.cause(), "JSON-RPC hot reload scan failed");
+                }
+                dispatch.run();
+            });
+        } else {
+            dispatch.run();
+        }
+    }
+
+    private record DispatchResult(JsonRPCResponse<?> response, Runnable postWrite) {
+        DispatchResult(JsonRPCResponse<?> response) {
+            this(response, null);
+        }
+
+        void runPostWrite() {
+            if (postWrite != null) {
+                postWrite.run();
+            }
         }
     }
 
     @SuppressWarnings("unchecked")
-    private void dispatchRoute(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
-        // Handle unsubscribe requests before normal method lookup
+    private Uni<DispatchResult> dispatchRoute(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
         if (JsonRPCKeys.UNSUBSCRIBE.equals(jsonRpcRequest.getMethod())) {
-            handleUnsubscribe(jsonRpcRequest, s);
-            return;
+            return handleUnsubscribe(jsonRpcRequest, s)
+                    .map(DispatchResult::new);
         }
 
         String key = Keys.createKey(jsonRpcRequest);
@@ -329,8 +412,8 @@ public class JsonRPCRouter {
                     }
                     LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", methodName,
                             jsonRpcRequest);
-                    codec.writeErrorResponse(s, jsonRpcRequest.getId(), methodName, unwrap(e));
-                    return;
+                    return Uni.createFrom()
+                            .item(new DispatchResult(errorResponse(jsonRpcRequest.getId(), methodName, unwrap(e))));
                 } finally {
                     if (activated) {
                         requestContext.deactivate();
@@ -345,41 +428,45 @@ public class JsonRPCRouter {
                 Map<String, Cancellable> subs = this.socketSubscriptions.computeIfAbsent(s,
                         k -> new ConcurrentHashMap<>());
 
-                // Use AtomicReference so cancel always targets the real cancellable,
-                // even if unsubscribe arrives before subscribe() returns
                 AtomicReference<Cancellable> ref = new AtomicReference<>(() -> {
                 });
                 subs.put(subscriptionId, () -> ref.get().cancel());
 
-                // Send ack before subscribing so client has subscription ID before items arrive
-                codec.writeResponse(s, jsonRpcRequest.getId(), subscriptionId);
-
+                final Multi<?> streamSource = multi;
                 if (m != null) {
-                    m.subscriptionStarted();
+                    m.recordSuccess(methodName, System.nanoTime() - startNanos);
                 }
 
-                Cancellable cancellable = multi.subscribe()
-                        .with(
-                                item -> codec.writeSubscriptionItem(s, subscriptionId, item),
-                                failure -> {
-                                    if (m != null) {
-                                        m.recordSubscriptionError(methodName);
-                                        m.subscriptionEnded();
-                                    }
-                                    codec.writeSubscriptionError(s, subscriptionId, methodName, unwrap(failure));
-                                    subs.remove(subscriptionId);
-                                },
-                                () -> {
-                                    if (m != null) {
-                                        m.subscriptionEnded();
-                                    }
-                                    codec.writeSubscriptionComplete(s, subscriptionId);
-                                    subs.remove(subscriptionId);
-                                });
+                // Defer Multi subscription until after the ack response is written,
+                // so synchronous Multi items don't arrive before the subscription ID
+                Runnable startSubscription = () -> {
+                    if (m != null) {
+                        m.subscriptionStarted();
+                    }
+                    Cancellable cancellable = streamSource.subscribe()
+                            .with(
+                                    item -> codec.writeSubscriptionItem(s, subscriptionId, item),
+                                    failure -> {
+                                        if (m != null) {
+                                            m.recordSubscriptionError(methodName);
+                                            m.subscriptionEnded();
+                                        }
+                                        codec.writeSubscriptionError(s, subscriptionId, methodName, unwrap(failure));
+                                        subs.remove(subscriptionId);
+                                    },
+                                    () -> {
+                                        if (m != null) {
+                                            m.subscriptionEnded();
+                                        }
+                                        codec.writeSubscriptionComplete(s, subscriptionId);
+                                        subs.remove(subscriptionId);
+                                    });
+                    ref.set(cancellable);
+                };
 
-                ref.set(cancellable);
+                JsonRPCResponse<?> ack = new JsonRPCResponse<>(jsonRpcRequest.getId(), (Object) subscriptionId);
+                return Uni.createFrom().item(new DispatchResult(ack, startSubscription));
             } else {
-                // The invocation will return a Uni<JsonObject>
                 Uni<?> uni;
                 try {
                     if (jsonRpcRequest.hasParams()) {
@@ -394,29 +481,49 @@ public class JsonRPCRouter {
                     }
                     LOG.errorf(e, "Unable to invoke method %s using JSON-RPC, request was: %s", methodName,
                             jsonRpcRequest);
-                    codec.writeErrorResponse(s, jsonRpcRequest.getId(), methodName, unwrap(e));
-                    return;
+                    return Uni.createFrom()
+                            .item(new DispatchResult(errorResponse(jsonRpcRequest.getId(), methodName, unwrap(e))));
                 }
-                uni.subscribe()
-                        .with(item -> {
+                return uni
+                        .<DispatchResult> map(item -> {
                             if (m != null) {
                                 m.recordSuccess(methodName, System.nanoTime() - startNanos);
                             }
-                            codec.writeResponse(s, jsonRpcRequest.getId(), item);
-                        }, failure -> {
+                            return new DispatchResult(new JsonRPCResponse<>(jsonRpcRequest.getId(), item));
+                        })
+                        .onFailure().recoverWithItem(failure -> {
                             if (m != null) {
                                 m.recordError(methodName, System.nanoTime() - startNanos);
                             }
-                            codec.writeErrorResponse(s, jsonRpcRequest.getId(), methodName, unwrap(failure));
+                            return new DispatchResult(
+                                    errorResponse(jsonRpcRequest.getId(), methodName, unwrap(failure)));
                         });
             }
         } else {
-            // Method not found
-            codec.writeMethodNotFoundResponse(s, jsonRpcRequest.getId(), jsonRpcRequest.getMethod());
+            return Uni.createFrom().item(new DispatchResult(new JsonRPCResponse<>(jsonRpcRequest.getId(),
+                    new JsonRPCResponse.Error(JsonRPCKeys.METHOD_NOT_FOUND,
+                            "Method [" + jsonRpcRequest.getMethod() + "] not found"))));
         }
     }
 
-    private void handleUnsubscribe(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
+    private static JsonRPCResponse<?> errorResponse(int id, String methodName, Throwable exception) {
+        int code = resolveErrorCode(exception);
+        LOG.error("Error in JsonRPC Call", exception);
+        return new JsonRPCResponse<>(id,
+                new JsonRPCResponse.Error(code, "Method [" + methodName + "] failed: " + exception.getMessage()));
+    }
+
+    private static int resolveErrorCode(Throwable exception) {
+        if (exception instanceof io.quarkus.security.UnauthorizedException) {
+            return JsonRPCKeys.UNAUTHORIZED;
+        }
+        if (exception instanceof io.quarkus.security.ForbiddenException) {
+            return JsonRPCKeys.FORBIDDEN;
+        }
+        return JsonRPCKeys.INTERNAL_ERROR;
+    }
+
+    private Uni<JsonRPCResponse<?>> handleUnsubscribe(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
         String subscriptionId = null;
         if (jsonRpcRequest.hasPositionedParams()) {
             Object[] params = jsonRpcRequest.getPositionedParams();
@@ -428,9 +535,10 @@ public class JsonRPCRouter {
         }
 
         if (subscriptionId == null) {
-            codec.writeErrorResponse(s, jsonRpcRequest.getId(), JsonRPCKeys.INVALID_PARAMS, JsonRPCKeys.UNSUBSCRIBE,
-                    new IllegalArgumentException("Missing required parameter: subscription ID"));
-            return;
+            return Uni.createFrom().item(new JsonRPCResponse<>(jsonRpcRequest.getId(),
+                    new JsonRPCResponse.Error(JsonRPCKeys.INVALID_PARAMS,
+                            "Method [" + JsonRPCKeys.UNSUBSCRIBE
+                                    + "] failed: Missing required parameter: subscription ID")));
         }
 
         Map<String, Cancellable> subs = socketSubscriptions.get(s);
@@ -442,11 +550,10 @@ public class JsonRPCRouter {
                 if (m != null) {
                     m.subscriptionEnded();
                 }
-                codec.writeResponse(s, jsonRpcRequest.getId(), true);
-                return;
+                return Uni.createFrom().item(new JsonRPCResponse<>(jsonRpcRequest.getId(), (Object) true));
             }
         }
-        codec.writeResponse(s, jsonRpcRequest.getId(), false);
+        return Uni.createFrom().item(new JsonRPCResponse<>(jsonRpcRequest.getId(), (Object) false));
     }
 
     private static Throwable unwrap(Throwable failure) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.runtime.model;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jboss.logging.Logger;
@@ -21,6 +22,14 @@ public class JsonRPCCodec {
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 
+    public JsonNode parseJson(String json) throws JsonProcessingException {
+        return objectMapper.readTree(json);
+    }
+
+    public JsonRPCRequest readRequest(JsonNode jsonNode) {
+        return new JsonRPCRequest(objectMapper, jsonNode);
+    }
+
     public JsonRPCRequest readRequest(String json) {
         try {
             JsonNode jsonNode = objectMapper.readTree(json);
@@ -30,12 +39,29 @@ public class JsonRPCCodec {
         }
     }
 
+    public void writeResponse(ServerWebSocket socket, JsonRPCResponse<?> response) {
+        try {
+            socket.writeTextMessage(objectMapper.writeValueAsString(response));
+        } catch (JsonProcessingException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void writeBatchResponse(ServerWebSocket socket, List<JsonRPCResponse<?>> responses) {
+        try {
+            socket.writeTextMessage(objectMapper.writeValueAsString(responses));
+        } catch (JsonProcessingException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     public void writeResponse(ServerWebSocket socket, int id, Object object) {
-        writeResponse(socket, new JsonRPCResponse(id, object));
+        writeResponse(socket, (JsonRPCResponse<?>) new JsonRPCResponse<>(id, object));
     }
 
     public void writeMethodNotFoundResponse(ServerWebSocket socket, int id, String jsonRpcMethodName) {
-        writeResponse(socket, new JsonRPCResponse(id,
+        writeResponse(socket, new JsonRPCResponse<>(id,
                 new JsonRPCResponse.Error(JsonRPCKeys.METHOD_NOT_FOUND, "Method [" + jsonRpcMethodName + "] not found")));
     }
 
@@ -57,7 +83,7 @@ public class JsonRPCCodec {
     public void writeErrorResponse(ServerWebSocket socket, int id, int code, String jsonRpcMethodName,
             Throwable exception) {
         LOG.error("Error in JsonRPC Call", exception);
-        writeResponse(socket, new JsonRPCResponse(id,
+        writeResponse(socket, new JsonRPCResponse<>(id,
                 new JsonRPCResponse.Error(code,
                         "Method [" + jsonRpcMethodName + "] failed: " + exception.getMessage())));
     }
@@ -87,14 +113,6 @@ public class JsonRPCCodec {
         params.put(JsonRPCKeys.SUBSCRIPTION, subscriptionId);
         params.put(JsonRPCKeys.COMPLETE, true);
         writeNotification(socket, new JsonRPCNotification(JsonRPCKeys.SUBSCRIPTION, params));
-    }
-
-    private void writeResponse(ServerWebSocket socket, JsonRPCResponse response) {
-        try {
-            socket.writeTextMessage(objectMapper.writeValueAsString(response));
-        } catch (JsonProcessingException ex) {
-            throw new RuntimeException(ex);
-        }
     }
 
     public void writeNotification(ServerWebSocket socket, JsonRPCNotification notification) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -55,39 +55,6 @@ public class JsonRPCCodec {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    public void writeResponse(ServerWebSocket socket, int id, Object object) {
-        writeResponse(socket, (JsonRPCResponse<?>) new JsonRPCResponse<>(id, object));
-    }
-
-    public void writeMethodNotFoundResponse(ServerWebSocket socket, int id, String jsonRpcMethodName) {
-        writeResponse(socket, new JsonRPCResponse<>(id,
-                new JsonRPCResponse.Error(JsonRPCKeys.METHOD_NOT_FOUND, "Method [" + jsonRpcMethodName + "] not found")));
-    }
-
-    public void writeErrorResponse(ServerWebSocket socket, int id, String jsonRpcMethodName, Throwable exception) {
-        int code = resolveErrorCode(exception);
-        writeErrorResponse(socket, id, code, jsonRpcMethodName, exception);
-    }
-
-    private int resolveErrorCode(Throwable exception) {
-        if (exception instanceof io.quarkus.security.UnauthorizedException) {
-            return JsonRPCKeys.UNAUTHORIZED;
-        }
-        if (exception instanceof io.quarkus.security.ForbiddenException) {
-            return JsonRPCKeys.FORBIDDEN;
-        }
-        return JsonRPCKeys.INTERNAL_ERROR;
-    }
-
-    public void writeErrorResponse(ServerWebSocket socket, int id, int code, String jsonRpcMethodName,
-            Throwable exception) {
-        LOG.error("Error in JsonRPC Call", exception);
-        writeResponse(socket, new JsonRPCResponse<>(id,
-                new JsonRPCResponse.Error(code,
-                        "Method [" + jsonRpcMethodName + "] failed: " + exception.getMessage())));
-    }
-
     public void writeSubscriptionItem(ServerWebSocket socket, String subscriptionId, Object item) {
         Map<String, Object> params = new LinkedHashMap<>();
         params.put(JsonRPCKeys.SUBSCRIPTION, subscriptionId);


### PR DESCRIPTION
The JSON-RPC 2.0 spec requires servers to accept an array of request objects and return an array of responses. Previously, sending a JSON array would throw a RuntimeException and likely close the connection.

This refactors `dispatchRoute()` from a fire-and-forget method that writes directly to the socket into one that returns `Uni<DispatchResult>`, enabling both single and batch request handling through the same dispatch logic. A `DispatchResult` pairs the response with an optional post-write callback, used for Multi subscriptions that must start after the ack is written to preserve message ordering.

For batch requests, all responses are collected via `Uni.join().all()` and returned as a single JSON array. Multi/streaming ack responses are included in the batch array, with subscription items delivered as individual notifications afterward. Parse errors (`-32700`) and empty batch arrays (`-32600`) now return proper JSON-RPC error responses instead of killing the connection.

Closes #126