### PR TITLE
Support String and Number types for request id per JSON-RPC 2.0 spec

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/FlexibleIdJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/FlexibleIdJsonRpcTest.java
@@ -1,0 +1,136 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class FlexibleIdJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testStringId() throws Exception {
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", "req-abc", "method", "HelloResource#hello");
+
+        JsonObject response = sendAndReceive(request);
+
+        Assertions.assertEquals("req-abc", response.getString("id"));
+        Assertions.assertTrue(response.getString("result").startsWith("Hello ["));
+    }
+
+    @Test
+    public void testLargeNumberId() throws Exception {
+        long largeId = 9007199254740993L;
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", largeId, "method", "HelloResource#hello");
+
+        JsonObject response = sendAndReceive(request);
+
+        Assertions.assertEquals(largeId, response.getLong("id"));
+        Assertions.assertTrue(response.getString("result").startsWith("Hello ["));
+    }
+
+    @Test
+    public void testNullId() throws Exception {
+        String rawRequest = "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"HelloResource#hello\"}";
+
+        String rawResponse = sendRaw(rawRequest);
+        JsonObject response = new JsonObject(rawResponse);
+
+        Assertions.assertNull(response.getValue("id"));
+        Assertions.assertTrue(response.getString("result").startsWith("Hello ["));
+    }
+
+    @Test
+    public void testStringIdWithParams() throws Exception {
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", "named-req",
+                "method", "HelloResource#hello", "params", JsonObject.of("name", "Alice"));
+
+        JsonObject response = sendAndReceive(request);
+
+        Assertions.assertEquals("named-req", response.getString("id"));
+        Assertions.assertTrue(response.getString("result").startsWith("Hello Alice ["));
+    }
+
+    @Test
+    public void testStringIdMethodNotFound() throws Exception {
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", "err-1", "method", "NoSuch#method");
+
+        JsonObject response = sendAndReceive(request);
+
+        Assertions.assertEquals("err-1", response.getString("id"));
+        Assertions.assertNotNull(response.getJsonObject("error"));
+        Assertions.assertEquals(-32601, response.getJsonObject("error").getInteger("code"));
+    }
+
+    @Test
+    public void testBatchWithMixedIdTypes() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "id", "str-1", "method", "HelloResource#hello"))
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 42, "method", "HelloResource#hello"));
+
+        String rawResponse = sendRaw(batch.encode());
+        JsonArray responses = new JsonArray(rawResponse);
+        Assertions.assertEquals(2, responses.size());
+
+        boolean foundString = false;
+        boolean foundInt = false;
+        for (int i = 0; i < responses.size(); i++) {
+            JsonObject r = responses.getJsonObject(i);
+            Object id = r.getValue("id");
+            if ("str-1".equals(id)) {
+                foundString = true;
+            } else if (Integer.valueOf(42).equals(id)) {
+                foundInt = true;
+            }
+        }
+        Assertions.assertTrue(foundString, "Expected response with string id 'str-1'");
+        Assertions.assertTrue(foundInt, "Expected response with int id 42");
+    }
+
+    private JsonObject sendAndReceive(JsonObject request) throws Exception {
+        return new JsonObject(sendRaw(request.encode()));
+    }
+
+    private String sendRaw(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            String response = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return response;
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 
 import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
@@ -244,13 +245,14 @@ public class JsonRPCRouter {
                 jsonNode = codec.parseJson(e);
             } catch (JsonProcessingException ex) {
                 codec.writeResponse(socket,
-                        new JsonRPCResponse<>(0, new JsonRPCResponse.Error(JsonRPCKeys.PARSE_ERROR, "Parse error")));
+                        new JsonRPCResponse<>(NullNode.instance,
+                                new JsonRPCResponse.Error(JsonRPCKeys.PARSE_ERROR, "Parse error")));
                 return;
             }
 
             if (jsonNode.isArray()) {
                 if (jsonNode.isEmpty()) {
-                    codec.writeResponse(socket, new JsonRPCResponse<>(0,
+                    codec.writeResponse(socket, new JsonRPCResponse<>(NullNode.instance,
                             new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request: empty batch")));
                     return;
                 }
@@ -316,7 +318,7 @@ public class JsonRPCRouter {
             List<Uni<DispatchResult>> unis = new ArrayList<>();
             for (JsonNode element : elements) {
                 if (!element.isObject() || !element.has(JsonRPCKeys.METHOD)) {
-                    int id = element.has(JsonRPCKeys.ID) ? element.get(JsonRPCKeys.ID).asInt(0) : 0;
+                    JsonNode id = element.has(JsonRPCKeys.ID) ? element.get(JsonRPCKeys.ID) : NullNode.instance;
                     unis.add(Uni.createFrom().item(new DispatchResult(new JsonRPCResponse<>(id,
                             new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request")))));
                 } else {
@@ -340,7 +342,7 @@ public class JsonRPCRouter {
                             },
                             failure -> {
                                 LOG.errorf(failure, "Unexpected error processing batch request");
-                                codec.writeResponse(s, new JsonRPCResponse<>(0,
+                                codec.writeResponse(s, new JsonRPCResponse<>(NullNode.instance,
                                         new JsonRPCResponse.Error(JsonRPCKeys.INTERNAL_ERROR,
                                                 "Internal error processing batch")));
                             });
@@ -518,7 +520,7 @@ public class JsonRPCRouter {
         }
     }
 
-    private static JsonRPCResponse<?> errorResponse(int id, String methodName, Throwable exception) {
+    private static JsonRPCResponse<?> errorResponse(JsonNode id, String methodName, Throwable exception) {
         int code = resolveErrorCode(exception);
         LOG.error("Error in JsonRPC Call", exception);
         return new JsonRPCResponse<>(id,

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -30,15 +30,6 @@ public class JsonRPCCodec {
         return new JsonRPCRequest(objectMapper, jsonNode);
     }
 
-    public JsonRPCRequest readRequest(String json) {
-        try {
-            JsonNode jsonNode = objectMapper.readTree(json);
-            return new JsonRPCRequest(objectMapper, jsonNode);
-        } catch (JsonProcessingException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
     public void writeResponse(ServerWebSocket socket, JsonRPCResponse<?> response) {
         try {
             socket.writeTextMessage(objectMapper.writeValueAsString(response));

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCRequest.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCRequest.java
@@ -32,8 +32,8 @@ public class JsonRPCRequest {
         this.paramOption = parametersProvidedAs();
     }
 
-    public int getId() {
-        return jsonNode.get(ID).asInt();
+    public JsonNode getId() {
+        return jsonNode.get(ID);
     }
 
     public String getJsonrpc() {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCResponse.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCResponse.java
@@ -1,19 +1,20 @@
 package io.quarkiverse.jsonrpc.runtime.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class JsonRPCResponse<T> {
 
-    // Public for serialization
-    public final int id;
+    public final JsonNode id;
     public final T result;
     public final Error error;
 
-    public JsonRPCResponse(int id, T result) {
+    public JsonRPCResponse(JsonNode id, T result) {
         this.id = id;
         this.result = result;
         this.error = null;
     }
 
-    public JsonRPCResponse(int id, Error error) {
+    public JsonRPCResponse(JsonNode id, Error error) {
         this.id = id;
         this.result = null;
         this.error = error;


### PR DESCRIPTION
The JSON-RPC 2.0 spec allows String, Number, or Null for the `id` field. Previously, the extension used `int` exclusively — string IDs silently became `0` and large numbers lost precision.

This changes the id type from `int` to Jackson `JsonNode` throughout the model layer (`JsonRPCRequest`, `JsonRPCResponse`) and router. `JsonNode` preserves the original JSON type, so responses echo back exactly what the client sent. Error responses where no id can be determined now use `null` per spec instead of `0`.

Also removes dead codec convenience methods (`readRequest(String)`, `writeMethodNotFoundResponse`, `writeErrorResponse`) that were superseded by the batch request refactor.

Closes #130