### PR TITLE
Support inbound notifications per JSON-RPC 2.0 spec

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/NotificationJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/NotificationJsonRpcTest.java
@@ -1,0 +1,155 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class NotificationJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testNotificationNoResponse() throws Exception {
+        JsonObject notification = JsonObject.of("jsonrpc", "2.0", "method", "HelloResource#hello");
+
+        String response = sendAndWaitForNoResponse(notification.encode());
+
+        Assertions.assertNull(response, "Server must not reply to a notification");
+    }
+
+    @Test
+    public void testNotificationWithParams() throws Exception {
+        JsonObject notification = JsonObject.of("jsonrpc", "2.0", "method", "HelloResource#hello",
+                "params", JsonObject.of("name", "Alice"));
+
+        String response = sendAndWaitForNoResponse(notification.encode());
+
+        Assertions.assertNull(response, "Server must not reply to a notification even with params");
+    }
+
+    @Test
+    public void testNotificationUnknownMethodNoResponse() throws Exception {
+        JsonObject notification = JsonObject.of("jsonrpc", "2.0", "method", "NoSuch#method");
+
+        String response = sendAndWaitForNoResponse(notification.encode());
+
+        Assertions.assertNull(response, "Server must not reply to a notification for an unknown method");
+    }
+
+    @Test
+    public void testBatchMixedNotificationsAndRequests() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "method", "HelloResource#hello"))
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello"))
+                .add(JsonObject.of("jsonrpc", "2.0", "method", "HelloResource#hello",
+                        "params", JsonObject.of("name", "Bob")))
+                .add(JsonObject.of("jsonrpc", "2.0", "id", 2, "method", "HelloResource#hello",
+                        "params", JsonObject.of("name", "Carol")));
+
+        String rawResponse = sendRaw(batch.encode());
+        JsonArray responses = new JsonArray(rawResponse);
+
+        Assertions.assertEquals(2, responses.size(), "Only non-notification requests should have responses");
+
+        boolean foundId1 = false;
+        boolean foundId2 = false;
+        for (int i = 0; i < responses.size(); i++) {
+            JsonObject r = responses.getJsonObject(i);
+            int id = r.getInteger("id");
+            if (id == 1) {
+                foundId1 = true;
+                Assertions.assertTrue(r.getString("result").startsWith("Hello ["));
+            } else if (id == 2) {
+                foundId2 = true;
+                Assertions.assertTrue(r.getString("result").startsWith("Hello Carol ["));
+            }
+        }
+        Assertions.assertTrue(foundId1, "Expected response for request id 1");
+        Assertions.assertTrue(foundId2, "Expected response for request id 2");
+    }
+
+    @Test
+    public void testBatchAllNotifications() throws Exception {
+        JsonArray batch = new JsonArray()
+                .add(JsonObject.of("jsonrpc", "2.0", "method", "HelloResource#hello"))
+                .add(JsonObject.of("jsonrpc", "2.0", "method", "HelloResource#hello",
+                        "params", JsonObject.of("name", "Dave")));
+
+        String response = sendAndWaitForNoResponse(batch.encode());
+
+        Assertions.assertNull(response, "Server must not reply when batch contains only notifications");
+    }
+
+    @Test
+    public void testNullIdIsNotNotification() throws Exception {
+        String rawRequest = "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"HelloResource#hello\"}";
+
+        String rawResponse = sendRaw(rawRequest);
+        JsonObject response = new JsonObject(rawResponse);
+
+        Assertions.assertTrue(response.containsKey("id"), "Request with null id should get a response");
+        Assertions.assertTrue(response.getString("result").startsWith("Hello ["));
+    }
+
+    private String sendRaw(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            String response = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return response;
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private String sendAndWaitForNoResponse(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            return queue.poll(2, TimeUnit.SECONDS);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -290,6 +290,7 @@ public class JsonRPCRouter {
     }
 
     private void route(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {
+        boolean notification = jsonRpcRequest.isNotification();
         if (JsonRPCHotReplacementSetup.isEnabled()) {
             Vertx.currentContext().<Void> executeBlocking(() -> {
                 JsonRPCHotReplacementSetup.scan();
@@ -300,15 +301,19 @@ public class JsonRPCRouter {
                 }
                 dispatchRoute(jsonRpcRequest, s)
                         .subscribe().with(result -> {
-                            codec.writeResponse(s, result.response);
-                            result.runPostWrite();
+                            if (!notification) {
+                                codec.writeResponse(s, result.response);
+                                result.runPostWrite();
+                            }
                         });
             });
         } else {
             dispatchRoute(jsonRpcRequest, s)
                     .subscribe().with(result -> {
-                        codec.writeResponse(s, result.response);
-                        result.runPostWrite();
+                        if (!notification) {
+                            codec.writeResponse(s, result.response);
+                            result.runPostWrite();
+                        }
                     });
         }
     }
@@ -323,7 +328,12 @@ public class JsonRPCRouter {
                             new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request")))));
                 } else {
                     JsonRPCRequest request = codec.readRequest(element);
-                    unis.add(dispatchRoute(request, s));
+                    boolean notification = request.isNotification();
+                    Uni<DispatchResult> uni = dispatchRoute(request, s);
+                    if (notification) {
+                        uni = uni.map(r -> new DispatchResult(r.response, r.postWrite, true));
+                    }
+                    unis.add(uni);
                 }
             }
             Uni.join().all(unis).andCollectFailures()
@@ -332,12 +342,16 @@ public class JsonRPCRouter {
                                 List<JsonRPCResponse<?>> responses = new ArrayList<>();
                                 List<Runnable> postWrites = new ArrayList<>();
                                 for (DispatchResult result : results) {
-                                    responses.add(result.response);
-                                    if (result.postWrite != null) {
-                                        postWrites.add(result.postWrite);
+                                    if (!result.notification) {
+                                        responses.add(result.response);
+                                        if (result.postWrite != null) {
+                                            postWrites.add(result.postWrite);
+                                        }
                                     }
                                 }
-                                codec.writeBatchResponse(s, responses);
+                                if (!responses.isEmpty()) {
+                                    codec.writeBatchResponse(s, responses);
+                                }
                                 postWrites.forEach(Runnable::run);
                             },
                             failure -> {
@@ -363,9 +377,9 @@ public class JsonRPCRouter {
         }
     }
 
-    private record DispatchResult(JsonRPCResponse<?> response, Runnable postWrite) {
+    private record DispatchResult(JsonRPCResponse<?> response, Runnable postWrite, boolean notification) {
         DispatchResult(JsonRPCResponse<?> response) {
-            this(response, null);
+            this(response, null, false);
         }
 
         void runPostWrite() {
@@ -479,7 +493,7 @@ public class JsonRPCRouter {
                 };
 
                 JsonRPCResponse<?> ack = new JsonRPCResponse<>(jsonRpcRequest.getId(), (Object) subscriptionId);
-                return Uni.createFrom().item(new DispatchResult(ack, startSubscription));
+                return Uni.createFrom().item(new DispatchResult(ack, startSubscription, false));
             } else {
                 Uni<?> uni;
                 try {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCRequest.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCRequest.java
@@ -36,6 +36,10 @@ public class JsonRPCRequest {
         return jsonNode.get(ID);
     }
 
+    public boolean isNotification() {
+        return !jsonNode.has(ID);
+    }
+
     public String getJsonrpc() {
         String value = jsonNode.get(JSONRPC).asText();
         if (value != null) {


### PR DESCRIPTION
The JSON-RPC 2.0 spec defines a notification as a request without an `id` field — the server must process it but must not send any response back.

This adds `isNotification()` to `JsonRPCRequest` (checks for absent `id` using Jackson's `has()`, correctly distinguishing absent from explicit `null`), and updates the router to suppress responses for notifications in both single-request and batch paths. For batches, notification responses are filtered from the response array, and an all-notification batch produces no response at all, per spec.

Closes #127