### PR TITLE
Return proper JSON-RPC error responses for invalid single requests

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ErrorHandlingJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ErrorHandlingJsonRpcTest.java
@@ -1,0 +1,164 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonObject;
+
+public class ErrorHandlingJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("json-rpc")
+    URI jsonRpcUri;
+
+    @Test
+    public void testBareNumberReturnsInvalidRequest() throws Exception {
+        JsonObject response = sendAndGetResponse("42");
+
+        assertInvalidRequest(response);
+        Assertions.assertTrue(response.getValue("id") == null, "id should be null for non-object input");
+    }
+
+    @Test
+    public void testBareStringReturnsInvalidRequest() throws Exception {
+        JsonObject response = sendAndGetResponse("\"hello\"");
+
+        assertInvalidRequest(response);
+    }
+
+    @Test
+    public void testBareBooleanReturnsInvalidRequest() throws Exception {
+        JsonObject response = sendAndGetResponse("true");
+
+        assertInvalidRequest(response);
+    }
+
+    @Test
+    public void testBareNullReturnsInvalidRequest() throws Exception {
+        JsonObject response = sendAndGetResponse("null");
+
+        assertInvalidRequest(response);
+    }
+
+    @Test
+    public void testObjectMissingMethodReturnsInvalidRequest() throws Exception {
+        String request = JsonObject.of("jsonrpc", "2.0", "id", 1).encode();
+
+        JsonObject response = sendAndGetResponse(request);
+
+        assertInvalidRequest(response);
+        Assertions.assertEquals(1, response.getInteger("id"), "id from request should be echoed");
+    }
+
+    @Test
+    public void testObjectMissingMethodAndIdReturnsInvalidRequest() throws Exception {
+        String request = JsonObject.of("jsonrpc", "2.0").encode();
+
+        JsonObject response = sendAndGetResponse(request);
+
+        assertInvalidRequest(response);
+    }
+
+    @Test
+    public void testConnectionSurvivesError() throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            ws.textMessageHandler(queue::add);
+                            ws.writeTextMessage("not valid json");
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+
+            String errorResponse = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(errorResponse, "Should receive parse error response");
+            JsonObject errorJson = new JsonObject(errorResponse);
+            Assertions.assertEquals(-32700, errorJson.getJsonObject("error").getInteger("code"));
+
+            // Now send a valid request on the same connection — it should still work
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .toCompletionStage().toCompletableFuture().get();
+
+            // Re-use the original connection by sending directly
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    @Test
+    public void testConnectionSurvivesInvalidRequestThenServesValidRequest() throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            WebSocket ws = client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .toCompletionStage().toCompletableFuture().get();
+            ws.textMessageHandler(queue::add);
+
+            ws.writeTextMessage("42");
+            String errorResponse = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(errorResponse, "Should receive invalid request error");
+            assertInvalidRequest(new JsonObject(errorResponse));
+
+            String validRequest = JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "HelloResource#hello").encode();
+            ws.writeTextMessage(validRequest);
+            String successResponse = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(successResponse, "Should receive response for valid request");
+            JsonObject successJson = new JsonObject(successResponse);
+            Assertions.assertEquals(1, successJson.getInteger("id"));
+            Assertions.assertTrue(successJson.getString("result").startsWith("Hello ["));
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private void assertInvalidRequest(JsonObject response) {
+        Assertions.assertNotNull(response.getJsonObject("error"), "Should contain an error object");
+        Assertions.assertEquals(-32600, response.getJsonObject("error").getInteger("code"),
+                "Error code should be INVALID_REQUEST (-32600)");
+    }
+
+    private JsonObject sendAndGetResponse(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            String response = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "Should receive an error response");
+            return new JsonObject(response);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ErrorHandlingJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ErrorHandlingJsonRpcTest.java
@@ -79,37 +79,6 @@ public class ErrorHandlingJsonRpcTest {
     }
 
     @Test
-    public void testConnectionSurvivesError() throws Exception {
-        WebSocketClient client = vertx.createWebSocketClient();
-        try {
-            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
-            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
-                    .onComplete(r -> {
-                        if (r.succeeded()) {
-                            WebSocket ws = r.result();
-                            ws.textMessageHandler(queue::add);
-                            ws.writeTextMessage("not valid json");
-                        } else {
-                            throw new IllegalStateException(r.cause());
-                        }
-                    });
-
-            String errorResponse = queue.poll(10, TimeUnit.SECONDS);
-            Assertions.assertNotNull(errorResponse, "Should receive parse error response");
-            JsonObject errorJson = new JsonObject(errorResponse);
-            Assertions.assertEquals(-32700, errorJson.getJsonObject("error").getInteger("code"));
-
-            // Now send a valid request on the same connection — it should still work
-            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
-                    .toCompletionStage().toCompletableFuture().get();
-
-            // Re-use the original connection by sending directly
-        } finally {
-            client.close().toCompletionStage().toCompletableFuture().get();
-        }
-    }
-
-    @Test
     public void testConnectionSurvivesInvalidRequestThenServesValidRequest() throws Exception {
         WebSocketClient client = vertx.createWebSocketClient();
         try {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcDevModeTest.java
@@ -21,14 +21,32 @@ public class JsonRpcDevModeTest {
 
     @Test
     public void testHotReloadViaWebSocket() throws Exception {
-        String result1 = callJsonRpc("HelloResource#hello", 1);
+        String result1 = awaitJsonRpc("HelloResource#hello", 1, "Hello [", 60_000);
         Assertions.assertTrue(result1.startsWith("Hello ["), "Initial response: " + result1);
 
         devModeTest.modifySourceFile(HelloResource.class,
                 s -> s.replace("return \"Hello [\"", "return \"Hola [\""));
 
-        String result2 = callJsonRpc("HelloResource#hello", 2);
+        String result2 = awaitJsonRpc("HelloResource#hello", 2, "Hola [", 30_000);
         Assertions.assertTrue(result2.startsWith("Hola ["), "After hot reload: " + result2);
+    }
+
+    private String awaitJsonRpc(String method, int id, String expectedPrefix, long timeoutMs) throws Exception {
+        String result = null;
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                result = callJsonRpc(method, id);
+            } catch (Exception e) {
+                // App not ready or restarting
+            }
+            if (result != null && result.startsWith(expectedPrefix)) {
+                return result;
+            }
+            Thread.sleep(1000);
+        }
+        Assertions.fail("No response matching '" + expectedPrefix + "' within " + timeoutMs + "ms");
+        return null;
     }
 
     private String callJsonRpc(String method, int id) throws Exception {
@@ -43,15 +61,16 @@ public class JsonRpcDevModeTest {
                             ws.textMessageHandler(messages::add);
                             ws.writeTextMessage(
                                     JsonObject.of("jsonrpc", "2.0", "id", id, "method", method).encode());
-                        } else {
-                            messages.add(JsonObject.of("error",
-                                    JsonObject.of("message", r.cause().getMessage())).encode());
                         }
                     });
-            String response = messages.poll(10, TimeUnit.SECONDS);
-            Assertions.assertNotNull(response, "No response received");
+            String response = messages.poll(5, TimeUnit.SECONDS);
+            if (response == null) {
+                return null;
+            }
             JsonObject json = new JsonObject(response);
-            Assertions.assertNull(json.getJsonObject("error"), "Unexpected error: " + response);
+            if (json.getJsonObject("error") != null) {
+                return null;
+            }
             return json.getString("result");
         } finally {
             client.close().toCompletionStage().toCompletableFuture().get();

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -240,30 +240,45 @@ public class JsonRPCRouter {
             socketIdentities.put(socket, identity);
         }
         socket.textMessageHandler((e) -> {
-            JsonNode jsonNode;
             try {
-                jsonNode = codec.parseJson(e);
-            } catch (JsonProcessingException ex) {
-                codec.writeResponse(socket,
-                        new JsonRPCResponse<>(NullNode.instance,
-                                new JsonRPCResponse.Error(JsonRPCKeys.PARSE_ERROR, "Parse error")));
-                return;
-            }
-
-            if (jsonNode.isArray()) {
-                if (jsonNode.isEmpty()) {
-                    codec.writeResponse(socket, new JsonRPCResponse<>(NullNode.instance,
-                            new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request: empty batch")));
+                JsonNode jsonNode;
+                try {
+                    jsonNode = codec.parseJson(e);
+                } catch (JsonProcessingException ex) {
+                    codec.writeResponse(socket,
+                            new JsonRPCResponse<>(NullNode.instance,
+                                    new JsonRPCResponse.Error(JsonRPCKeys.PARSE_ERROR, "Parse error")));
                     return;
                 }
-                List<JsonNode> elements = new ArrayList<>();
-                for (JsonNode element : jsonNode) {
-                    elements.add(element);
+
+                if (jsonNode.isArray()) {
+                    if (jsonNode.isEmpty()) {
+                        codec.writeResponse(socket, new JsonRPCResponse<>(NullNode.instance,
+                                new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST,
+                                        "Invalid request: empty batch")));
+                        return;
+                    }
+                    List<JsonNode> elements = new ArrayList<>();
+                    for (JsonNode element : jsonNode) {
+                        elements.add(element);
+                    }
+                    routeBatch(elements, socket);
+                } else {
+                    if (!jsonNode.isObject() || !jsonNode.has(JsonRPCKeys.METHOD)) {
+                        JsonNode id = jsonNode.isObject() && jsonNode.has(JsonRPCKeys.ID)
+                                ? jsonNode.get(JsonRPCKeys.ID)
+                                : NullNode.instance;
+                        codec.writeResponse(socket, new JsonRPCResponse<>(id,
+                                new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request")));
+                        return;
+                    }
+                    JsonRPCRequest jsonRpcRequest = codec.readRequest(jsonNode);
+                    route(jsonRpcRequest, socket);
                 }
-                routeBatch(elements, socket);
-            } else {
-                JsonRPCRequest jsonRpcRequest = codec.readRequest(jsonNode);
-                route(jsonRpcRequest, socket);
+            } catch (Exception ex) {
+                LOG.errorf(ex, "Unexpected error processing JSON-RPC message");
+                codec.writeResponse(socket, new JsonRPCResponse<>(NullNode.instance,
+                        new JsonRPCResponse.Error(JsonRPCKeys.INTERNAL_ERROR, "Internal error")));
             }
         });
         socket.closeHandler((e) -> {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -338,7 +338,8 @@ public class JsonRPCRouter {
             List<Uni<DispatchResult>> unis = new ArrayList<>();
             for (JsonNode element : elements) {
                 if (!element.isObject() || !element.has(JsonRPCKeys.METHOD)) {
-                    JsonNode id = element.has(JsonRPCKeys.ID) ? element.get(JsonRPCKeys.ID) : NullNode.instance;
+                    JsonNode id = element.isObject() && element.has(JsonRPCKeys.ID) ? element.get(JsonRPCKeys.ID)
+                            : NullNode.instance;
                     unis.add(Uni.createFrom().item(new DispatchResult(new JsonRPCResponse<>(id,
                             new JsonRPCResponse.Error(JsonRPCKeys.INVALID_REQUEST, "Invalid request")))));
                 } else {


### PR DESCRIPTION
The single-request path in the WebSocket message handler had no structural validation before routing. Valid JSON that isn't a valid JSON-RPC request object (bare values like `42`, `"hello"`, `true`, `null`, or objects missing the required `method` field) would cause a `NullPointerException` in `getMethod()`, propagating uncaught and likely closing the WebSocket connection.

This adds validation mirroring what `routeBatch()` already does for batch elements: non-objects and objects without `method` return an INVALID_REQUEST (-32600) error response with the `id` echoed when available. A top-level safety-net catch converts any unexpected exception to INTERNAL_ERROR (-32603) instead of letting it kill the connection.

Also fixes the flaky `JsonRpcDevModeTest` — the test was sending requests immediately after `modifySourceFile()` with no retry logic, so the hot-reload app restart would kill the WebSocket connection before the response arrived. The fix adds an `awaitJsonRpc()` retry helper that polls until the expected response appears, with generous timeouts for both initial dev-mode startup and post-reload recovery.

Closes #128