### PR TITLE
Support void methods as JSON-RPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Connect to `ws://localhost:8080/json-rpc` and send:
 - **JSON-RPC 2.0** — full protocol compliance including error codes and notifications
 - **WebSocket transport** — bidirectional communication out of the box
 - **Reactive** — `Uni<T>` for async results, `Multi<T>` for streaming subscriptions
+- **Fire-and-forget** — `void` methods for notification-style calls with no response
 - **Blocking & non-blocking** — control execution threads with `@Blocking` and `@NonBlocking`
 - **Server push** — broadcast notifications to all clients or target specific sessions
 - **Named & positional parameters** — both JSON object and array parameter styles

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -125,76 +125,73 @@ public class JsonRPCProcessor {
             for (MethodInfo method : methods) {
                 if (!method.name().equals(CONSTRUCTOR)) { // Ignore constructor
                     if (Modifier.isPublic(method.flags())) { // Only allow public methods
-                        if (method.returnType().kind() != Type.Kind.VOID) { // TODO: Only allow method with response ? Maybe not
-
-                            if (method.hasAnnotation(Blocking.class) && method.hasAnnotation(NonBlocking.class)) {
+                        if (method.hasAnnotation(Blocking.class) && method.hasAnnotation(NonBlocking.class)) {
+                            throw new IllegalArgumentException(
+                                    "Method " + classInfo.name() + "." + method.name()
+                                            + " cannot be annotated with both @Blocking and @NonBlocking");
+                        }
+                        if (method.hasAnnotation(RunOnVirtualThread.class)
+                                && method.hasAnnotation(NonBlocking.class)) {
+                            throw new IllegalArgumentException(
+                                    "Method " + classInfo.name() + "." + method.name()
+                                            + " cannot be annotated with both @RunOnVirtualThread and @NonBlocking");
+                        }
+                        if (method.hasAnnotation(RunOnVirtualThread.class)) {
+                            String returnTypeName = method.returnType().name().toString();
+                            if (returnTypeName.equals("io.smallrye.mutiny.Multi")
+                                    || returnTypeName.equals("java.util.concurrent.Flow$Publisher")) {
                                 throw new IllegalArgumentException(
                                         "Method " + classInfo.name() + "." + method.name()
-                                                + " cannot be annotated with both @Blocking and @NonBlocking");
+                                                + " cannot use @RunOnVirtualThread with a streaming return type"
+                                                + " (Multi/Flow.Publisher)");
                             }
-                            if (method.hasAnnotation(RunOnVirtualThread.class)
-                                    && method.hasAnnotation(NonBlocking.class)) {
-                                throw new IllegalArgumentException(
-                                        "Method " + classInfo.name() + "." + method.name()
-                                                + " cannot be annotated with both @RunOnVirtualThread and @NonBlocking");
-                            }
-                            if (method.hasAnnotation(RunOnVirtualThread.class)) {
-                                String returnTypeName = method.returnType().name().toString();
-                                if (returnTypeName.equals("io.smallrye.mutiny.Multi")
-                                        || returnTypeName.equals("java.util.concurrent.Flow$Publisher")) {
-                                    throw new IllegalArgumentException(
-                                            "Method " + classInfo.name() + "." + method.name()
-                                                    + " cannot use @RunOnVirtualThread with a streaming return type"
-                                                    + " (Multi/Flow.Publisher)");
-                                }
-                            }
-                            if (method.hasAnnotation(RunOnVirtualThread.class)
-                                    && method.hasAnnotation(Blocking.class)) {
-                                LOG.warnf("Method %s.%s is annotated with both @RunOnVirtualThread and @Blocking."
-                                        + " @Blocking is redundant and will be ignored.",
-                                        classInfo.name(), method.name());
-                            }
+                        }
+                        if (method.hasAnnotation(RunOnVirtualThread.class)
+                                && method.hasAnnotation(Blocking.class)) {
+                            LOG.warnf("Method %s.%s is annotated with both @RunOnVirtualThread and @Blocking."
+                                    + " @Blocking is redundant and will be ignored.",
+                                    classInfo.name(), method.name());
+                        }
 
-                            ExecutionMode executionMode;
-                            if (method.hasAnnotation(RunOnVirtualThread.class)) {
-                                executionMode = ExecutionMode.VIRTUAL_THREAD;
-                            } else if (method.hasAnnotation(Blocking.class)) {
-                                executionMode = ExecutionMode.BLOCKING;
-                            } else if (method.hasAnnotation(NonBlocking.class)) {
-                                executionMode = ExecutionMode.NON_BLOCKING;
-                            } else {
-                                executionMode = ExecutionMode.DEFAULT;
+                        ExecutionMode executionMode;
+                        if (method.hasAnnotation(RunOnVirtualThread.class)) {
+                            executionMode = ExecutionMode.VIRTUAL_THREAD;
+                        } else if (method.hasAnnotation(Blocking.class)) {
+                            executionMode = ExecutionMode.BLOCKING;
+                        } else if (method.hasAnnotation(NonBlocking.class)) {
+                            executionMode = ExecutionMode.NON_BLOCKING;
+                        } else {
+                            executionMode = ExecutionMode.DEFAULT;
+                        }
+
+                        String fullName = null;
+
+                        if (method.parametersCount() > 0) {
+                            Map<String, Class> params = new LinkedHashMap<>(); // Keep the order
+                            for (int i = 0; i < method.parametersCount(); i++) {
+                                Type parameterType = method.parameterType(i);
+                                Class parameterClass = toClass(parameterType);
+                                String parameterName = method.parameterName(i);
+                                params.put(parameterName, parameterClass);
+                                nativeClasses.addAll(getEffectiveTypes(parameterType));
                             }
+                            fullName = Keys.createKey(scope, method.name(), params.keySet());
 
-                            String fullName = null;
+                            JsonRPCMethodName jsonRpcMethodName = new JsonRPCMethodName(fullName,
+                                    Keys.createOrderedParameterKey(scope, method.name(), method.parametersCount()));
+                            JsonRPCMethod jsonRpcMethod = new JsonRPCMethod(clazz, method.name(), params);
+                            jsonRpcMethod.setExecutionMode(executionMode);
+                            methodsMap.put(jsonRpcMethodName, jsonRpcMethod);
+                        } else {
+                            fullName = Keys.createKey(scope, method.name());
+                            JsonRPCMethodName jsonRpcMethodName = new JsonRPCMethodName(fullName, null);
+                            JsonRPCMethod jsonRpcMethod = new JsonRPCMethod(clazz, method.name(), null);
+                            jsonRpcMethod.setExecutionMode(executionMode);
+                            methodsMap.put(jsonRpcMethodName, jsonRpcMethod);
+                        }
 
-                            if (method.parametersCount() > 0) {
-                                Map<String, Class> params = new LinkedHashMap<>(); // Keep the order
-                                for (int i = 0; i < method.parametersCount(); i++) {
-                                    Type parameterType = method.parameterType(i);
-                                    Class parameterClass = toClass(parameterType);
-                                    String parameterName = method.parameterName(i);
-                                    params.put(parameterName, parameterClass);
-                                    nativeClasses.addAll(getEffectiveTypes(parameterType));
-                                }
-                                fullName = Keys.createKey(scope, method.name(), params.keySet());
-
-                                JsonRPCMethodName jsonRpcMethodName = new JsonRPCMethodName(fullName,
-                                        Keys.createOrderedParameterKey(scope, method.name(), method.parametersCount()));
-                                JsonRPCMethod jsonRpcMethod = new JsonRPCMethod(clazz, method.name(), params);
-                                jsonRpcMethod.setExecutionMode(executionMode);
-                                methodsMap.put(jsonRpcMethodName, jsonRpcMethod);
-                            } else {
-                                fullName = Keys.createKey(scope, method.name());
-                                JsonRPCMethodName jsonRpcMethodName = new JsonRPCMethodName(fullName, null);
-                                JsonRPCMethod jsonRpcMethod = new JsonRPCMethod(clazz, method.name(), null);
-                                jsonRpcMethod.setExecutionMode(executionMode);
-                                methodsMap.put(jsonRpcMethodName, jsonRpcMethod);
-                            }
-
-                            // Add the return type
+                        if (method.returnType().kind() != Type.Kind.VOID) {
                             nativeClasses.addAll(getEffectiveTypes(method.returnType()));
-
                         }
                     }
                 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/VoidResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/VoidResource.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.common.annotation.NonBlocking;
+
+@JsonRPCApi
+public class VoidResource {
+
+    private static volatile String lastMessage;
+
+    public void fireAndForget() {
+        lastMessage = "fired";
+    }
+
+    public void fireAndForget(String message) {
+        lastMessage = message;
+    }
+
+    @NonBlocking
+    public void fireAndForgetNonBlocking() {
+        lastMessage = "fired-nb";
+    }
+
+    public static String getLastMessage() {
+        return lastMessage;
+    }
+
+    public static void resetLastMessage() {
+        lastMessage = null;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/VoidJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/VoidJsonRpcTest.java
@@ -1,0 +1,127 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.VoidResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.json.JsonObject;
+
+public class VoidJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(VoidResource.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("json-rpc")
+    URI jsonRpcUri;
+
+    @BeforeEach
+    public void reset() {
+        VoidResource.resetLastMessage();
+    }
+
+    @Test
+    public void testVoidMethodWithId() throws Exception {
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "VoidResource#fireAndForget");
+
+        String rawResponse = sendRaw(request.encode());
+        JsonObject response = new JsonObject(rawResponse);
+
+        Assertions.assertEquals(1, response.getInteger("id"));
+        Assertions.assertTrue(response.containsKey("result"), "Void method should return a result field");
+        Assertions.assertNull(response.getValue("result"), "Void method result should be null");
+        Assertions.assertEquals("fired", VoidResource.getLastMessage());
+    }
+
+    @Test
+    public void testVoidMethodWithParamsAndId() throws Exception {
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 2, "method", "VoidResource#fireAndForget",
+                "params", JsonObject.of("message", "hello"));
+
+        String rawResponse = sendRaw(request.encode());
+        JsonObject response = new JsonObject(rawResponse);
+
+        Assertions.assertEquals(2, response.getInteger("id"));
+        Assertions.assertTrue(response.containsKey("result"));
+        Assertions.assertNull(response.getValue("result"));
+        Assertions.assertEquals("hello", VoidResource.getLastMessage());
+    }
+
+    @Test
+    public void testVoidMethodAsNotification() throws Exception {
+        JsonObject notification = JsonObject.of("jsonrpc", "2.0", "method", "VoidResource#fireAndForget");
+
+        String response = sendAndWaitForNoResponse(notification.encode());
+
+        Assertions.assertNull(response, "Server must not reply to a void notification");
+        Assertions.assertEquals("fired", VoidResource.getLastMessage());
+    }
+
+    @Test
+    public void testVoidMethodNonBlocking() throws Exception {
+        JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 3, "method",
+                "VoidResource#fireAndForgetNonBlocking");
+
+        String rawResponse = sendRaw(request.encode());
+        JsonObject response = new JsonObject(rawResponse);
+
+        Assertions.assertEquals(3, response.getInteger("id"));
+        Assertions.assertNull(response.getValue("result"));
+        Assertions.assertEquals("fired-nb", VoidResource.getLastMessage());
+    }
+
+    private String sendRaw(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            String response = queue.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(response, "No response received within timeout");
+            return response;
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+
+    private String sendAndWaitForNoResponse(String message) throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            r.result().textMessageHandler(queue::add);
+                            r.result().writeTextMessage(message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+            return queue.poll(2, TimeUnit.SECONDS);
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -23,7 +23,7 @@ public class GreetingService {
 }
 ----
 
-The extension discovers annotated classes at build time. Each public method with a non-void return type becomes a JSON-RPC method.
+The extension discovers annotated classes at build time. Each public method becomes a JSON-RPC method.
 
 == Method Names
 
@@ -56,9 +56,9 @@ Now the method is called as `greet#hello` instead of `GreetingService#hello`. Th
 The following rules apply when the extension scans your class:
 
 - Only **public** methods are exposed.
-- Methods **must** have a non-void return type.
 - Constructors and static methods are ignored.
 - Private and package-private methods are ignored.
+- Methods may return any type, including `void` (see <<void-methods>> below).
 
 == CDI Integration
 
@@ -77,6 +77,48 @@ public class OrderService {
     }
 }
 ----
+
+[#void-methods]
+== Void Methods (Fire-and-Forget)
+
+Methods returning `void` are supported for fire-and-forget operations. They pair naturally with JSON-RPC https://www.jsonrpc.org/specification#notification[notifications] — requests sent without an `id`:
+
+[source,java]
+----
+@JsonRPCApi
+public class EventService {
+
+    public void trackEvent(String name) {
+        // process the event — no result to return
+    }
+}
+----
+
+The client sends a notification (no `id` field):
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "method": "EventService#trackEvent",
+  "params": { "name": "page_view" }
+}
+----
+
+The server executes the method and sends no response.
+
+If the client _does_ include an `id`, the server responds with `"result": null` per the JSON-RPC 2.0 specification:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": null
+}
+----
+
+Void methods follow the same execution mode rules as any other method — they are blocking by default and can be annotated with `@NonBlocking` or `@RunOnVirtualThread`. See xref:guides-execution-modes.adoc[Execution Modes & Return Types].
 
 == WebSocket Endpoint
 

--- a/docs/modules/ROOT/pages/guides-execution-modes.adoc
+++ b/docs/modules/ROOT/pages/guides-execution-modes.adoc
@@ -156,6 +156,10 @@ To use `@RunOnVirtualThread`, add the `quarkus-virtual-threads` extension to you
 |===
 | Return type | Default | Override
 
+| `void`
+| Blocking
+| `@NonBlocking`, `@RunOnVirtualThread`
+
 | Plain type
 | Blocking
 | `@NonBlocking`, `@RunOnVirtualThread`


### PR DESCRIPTION
Public methods returning `void` in `@JsonRPCApi` classes were silently skipped during build-time scanning. With inbound notification support already in place (#141), void methods are a natural fit for fire-and-forget operations.

The build-time filter in `JsonRPCProcessor` that excluded void return types has been removed. At runtime, `Method.invoke()` on a void method returns `null`, which flows through the existing dispatch path and serializes as `"result": null` — so no router changes were needed.

**Behavior:**
- Client sends a request **with `id`** → server executes the method and responds with `{"result": null}`
- Client sends a **notification** (no `id`) → server executes the method and sends no response

Void methods follow the same execution mode rules as any other method (blocking by default, overridable with `@NonBlocking` or `@RunOnVirtualThread`).

Closes #131