### PR TITLE
Add notify() to JS client and generate it for void methods

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -433,16 +433,21 @@ public class JsonRPCProcessor {
 
     private boolean isVoidReturnType(JsonRPCMethod method) {
         int paramCount = method.hasParams() ? method.getParams().size() : 0;
+        java.lang.reflect.Method m = findMethod(method.getClazz(), method.getMethodName(), paramCount);
+        return m != null && m.getReturnType() == void.class;
+    }
+
+    private java.lang.reflect.Method findMethod(Class<?> clazz, String methodName, int paramCount) {
         try {
-            for (java.lang.reflect.Method m : method.getClazz().getMethods()) {
-                if (m.getName().equals(method.getMethodName()) && m.getParameterCount() == paramCount) {
-                    return m.getReturnType() == void.class;
+            for (java.lang.reflect.Method m : clazz.getMethods()) {
+                if (m.getName().equals(methodName) && m.getParameterCount() == paramCount) {
+                    return m;
                 }
             }
         } catch (Exception e) {
-            LOG.debugf(e, "Failed to inspect return type of %s.%s", method.getClazz().getName(), method.getMethodName());
+            LOG.debugf(e, "Failed to inspect method %s.%s", clazz.getName(), methodName);
         }
-        return false;
+        return null;
     }
 
     private String jsClientMethod(JsonRPCMethod method) {

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -351,7 +351,7 @@ public class JsonRPCProcessor {
         // Group methods by scope and method name (sorted for deterministic output).
         // Multiple overloads of the same method name share one JS proxy entry — the server
         // resolves the correct overload based on parameters. We validate that all overloads
-        // agree on streaming vs non-streaming return type.
+        // agree on their JS client method category (call / subscribe / notify).
         Map<String, Map<String, MethodEntry>> byScope = new java.util.TreeMap<>();
         for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> entry : methodsMap.entrySet()) {
             String key = entry.getKey().getName();
@@ -363,16 +363,15 @@ public class JsonRPCProcessor {
             Map<String, MethodEntry> scopeMethods = byScope.computeIfAbsent(scope, k -> new java.util.TreeMap<>());
             MethodEntry existing = scopeMethods.get(methodName);
             if (existing != null) {
-                // Overloaded method — verify return types agree on streaming vs non-streaming
-                boolean existingStreaming = isStreamingReturnType(existing.method);
-                boolean newStreaming = isStreamingReturnType(entry.getValue());
-                if (existingStreaming != newStreaming) {
+                String existingCategory = jsClientMethod(existing.method);
+                String newCategory = jsClientMethod(entry.getValue());
+                if (!existingCategory.equals(newCategory)) {
                     throw new IllegalArgumentException(
                             "Overloaded method '" + scope + "#" + methodName + "' has conflicting return types: "
-                                    + "some overloads return a streaming type (Multi/Flow.Publisher) while others do not. "
-                                    + "The JavaScript client proxy cannot represent both call() and subscribe() "
-                                    + "under the same method name. Rename one of the overloads or make all overloads "
-                                    + "return the same category (all streaming or all non-streaming).");
+                                    + "some overloads use " + existingCategory + "() while others use " + newCategory
+                                    + "(). "
+                                    + "The JavaScript client proxy cannot represent both under the same method name. "
+                                    + "Rename one of the overloads or make all overloads return the same category.");
                 }
             } else {
                 scopeMethods.put(methodName, new MethodEntry(scope, methodName, entry.getValue()));
@@ -386,8 +385,7 @@ public class JsonRPCProcessor {
             js.append("export const ").append(scope).append(" = {\n");
             int i = 0;
             for (MethodEntry me : methods.values()) {
-                boolean streaming = isStreamingReturnType(me.method);
-                String clientMethod = streaming ? "subscribe" : "call";
+                String clientMethod = jsClientMethod(me.method);
                 String methodKey = me.scope + "#" + me.methodName;
                 js.append("    ").append(me.methodName)
                         .append(": (params) => client.").append(clientMethod)
@@ -431,6 +429,30 @@ public class JsonRPCProcessor {
     private boolean isStreamingReturnType(JsonRPCMethod method) {
         int paramCount = method.hasParams() ? method.getParams().size() : 0;
         return isReturnTypeAssignableTo(method.getClazz(), method.getMethodName(), paramCount, STREAMING_TYPES);
+    }
+
+    private boolean isVoidReturnType(JsonRPCMethod method) {
+        int paramCount = method.hasParams() ? method.getParams().size() : 0;
+        try {
+            for (java.lang.reflect.Method m : method.getClazz().getMethods()) {
+                if (m.getName().equals(method.getMethodName()) && m.getParameterCount() == paramCount) {
+                    return m.getReturnType() == void.class;
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugf(e, "Failed to inspect return type of %s.%s", method.getClazz().getName(), method.getMethodName());
+        }
+        return false;
+    }
+
+    private String jsClientMethod(JsonRPCMethod method) {
+        if (isStreamingReturnType(method)) {
+            return "subscribe";
+        } else if (isVoidReturnType(method)) {
+            return "notify";
+        } else {
+            return "call";
+        }
     }
 
     private record MethodEntry(String scope, String methodName, JsonRPCMethod method) {

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -258,6 +258,21 @@ export class JsonRPCClient {
     }
 
     /**
+     * Send a JSON-RPC notification (fire-and-forget, no response expected).
+     *
+     * @param {string} method - Method key, e.g. "EventService#trackEvent"
+     * @param {Object|Array} [params] - Named params object or positional params array
+     */
+    notify(method, params) {
+        const msg = { jsonrpc: '2.0', method };
+        if (params != null) msg.params = params;
+        if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
+            throw new Error('WebSocket not connected');
+        }
+        this._ws.send(JSON.stringify(msg));
+    }
+
+    /**
      * Cancel a streaming subscription by its ID.
      *
      * @param {string} subscriptionId - UUID returned by the subscription ACK

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ConflictingVoidReturnTypeResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ConflictingVoidReturnTypeResource.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class ConflictingVoidReturnTypeResource {
+
+    public void process() {
+    }
+
+    public String process(String input) {
+        return "processed: " + input;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientConflictingVoidReturnTypeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientConflictingVoidReturnTypeTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.ConflictingVoidReturnTypeResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JsClientConflictingVoidReturnTypeTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ConflictingVoidReturnTypeResource.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true")
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof IllegalArgumentException,
+                        "Expected IllegalArgumentException but got: " + t.getClass().getName());
+                Assertions.assertTrue(t.getMessage().contains("conflicting return types"),
+                        "Expected message about conflicting return types but got: " + t.getMessage());
+            });
+
+    @Test
+    public void testValidationFails() {
+        Assertions.fail("Should not reach here — build should have failed");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -8,6 +8,7 @@ import io.quarkiverse.jsonrpc.app.HelloResource;
 import io.quarkiverse.jsonrpc.app.Pojo;
 import io.quarkiverse.jsonrpc.app.Pojo2;
 import io.quarkiverse.jsonrpc.app.PojoResource;
+import io.quarkiverse.jsonrpc.app.VoidResource;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class JsClientGenerationTest extends JsClientTestBase {
@@ -15,7 +16,7 @@ public class JsClientGenerationTest extends JsClientTestBase {
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
-                root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class);
+                root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class, VoidResource.class);
             })
             .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true");
 
@@ -62,6 +63,25 @@ public class JsClientGenerationTest extends JsClientTestBase {
                 "Multi methods should use client.subscribe()");
         Assertions.assertTrue(body.contains("pojoMulti: (params) => client.subscribe('PojoResource#pojoMulti'"),
                 "Multi methods on PojoResource should use client.subscribe()");
+    }
+
+    @Test
+    public void testProxyUsesNotifyForVoidMethods() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
+        Assertions.assertTrue(body.contains("export const VoidResource"),
+                "Proxy should export VoidResource scope");
+        Assertions.assertTrue(body.contains("fireAndForget: (params) => client.notify('VoidResource#fireAndForget'"),
+                "Void methods should use client.notify()");
+        Assertions.assertTrue(
+                body.contains("fireAndForgetNonBlocking: (params) => client.notify('VoidResource#fireAndForgetNonBlocking'"),
+                "Void @NonBlocking methods should also use client.notify()");
+    }
+
+    @Test
+    public void testClientLibraryContainsNotifyMethod() throws Exception {
+        String body = httpGet("/_static/quarkus-json-rpc/jsonrpc-client.js");
+        Assertions.assertTrue(body.contains("notify(method, params)"),
+                "Client library should contain notify() method");
     }
 
 }

--- a/docs/modules/ROOT/pages/guides-javascript-client.adoc
+++ b/docs/modules/ROOT/pages/guides-javascript-client.adoc
@@ -46,6 +46,21 @@ const full = await GreetingService.greet({ name: 'Jane', surname: 'Doe' });
 
 Each method on the proxy accepts a params object (named parameters) or an array (positional parameters), matching the server-side Java method signature.
 
+=== Void Methods (Fire-and-Forget)
+
+Methods returning `void` on the server are exposed as fire-and-forget notifications. The proxy uses `client.notify()` instead of `client.call()`, so no response is sent back:
+
+[source,javascript]
+----
+import { EventService } from '@quarkiverse/json-rpc-api';
+
+// Fire-and-forget — no response, no Promise
+EventService.trackEvent({ name: 'page_view' });
+EventService.ping();
+----
+
+Under the hood, the proxy sends a JSON-RPC https://www.jsonrpc.org/specification#notification[notification] (a request without an `id` field). The server executes the method but sends no response.
+
 === Streaming Methods
 
 Methods that return `Multi<T>` or `Flow.Publisher<T>` on the server are automatically exposed as subscriptions:
@@ -109,6 +124,22 @@ const result2 = await client.call('GreetingService#hello', ['World']);
 // No parameters
 const result3 = await client.call('GreetingService#hello');
 ----
+
+=== Notifications (Fire-and-Forget)
+
+[source,javascript]
+----
+// Fire-and-forget — no response expected
+client.notify('EventService#trackEvent', { name: 'page_view' });
+
+// With positional parameters
+client.notify('EventService#trackEvent', ['page_view']);
+
+// No parameters
+client.notify('EventService#ping');
+----
+
+`notify()` sends a JSON-RPC notification (no `id` field). The server executes the method but sends no response. Throws if the WebSocket is not connected.
 
 === Subscriptions
 

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/EventResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/EventResource.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.jsonrpc.sample;
+
+import java.util.logging.Logger;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class EventResource {
+
+    private static final Logger LOG = Logger.getLogger(EventResource.class.getName());
+
+    public void trackEvent(String name) {
+        LOG.info("Event tracked: " + name);
+    }
+
+    public void ping() {
+        LOG.info("Ping received");
+    }
+}

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/EventResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/EventResource.java
@@ -1,16 +1,16 @@
 package io.quarkiverse.jsonrpc.sample;
 
-import java.util.logging.Logger;
+import org.jboss.logging.Logger;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCApi;
 
 @JsonRPCApi
 public class EventResource {
 
-    private static final Logger LOG = Logger.getLogger(EventResource.class.getName());
+    private static final Logger LOG = Logger.getLogger(EventResource.class);
 
     public void trackEvent(String name) {
-        LOG.info("Event tracked: " + name);
+        LOG.infof("Event tracked: %s", name);
     }
 
     public void ping() {

--- a/sample/src/main/resources/web/app/jsonrpc-app.js
+++ b/sample/src/main/resources/web/app/jsonrpc-app.js
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'lit';
-import {client, HelloResource, PojoResource, CollectionResource, SecuredResource, scoped} from '@quarkiverse/json-rpc-api';
+import {client, HelloResource, PojoResource, CollectionResource, SecuredResource, EventResource, scoped} from '@quarkiverse/json-rpc-api';
 
 class JsonRpcApp extends LitElement {
 
@@ -236,6 +236,16 @@ class JsonRpcApp extends LitElement {
         }
     }
 
+    _notify(label, fn) {
+        this._addMessage('sent', {notify: label});
+        try {
+            fn();
+            this._addMessage('received', {result: '(no response — fire-and-forget)'});
+        } catch (err) {
+            this._addMessage('error', {error: String(err)});
+        }
+    }
+
     _subscribe(label, fn) {
         this._addMessage('sent', {subscribe: label});
         const sub = fn()
@@ -355,6 +365,11 @@ class JsonRpcApp extends LitElement {
             ['userDashboard() @RolesAllowed("user")', () => SecuredResource.userDashboard()],
         ];
 
+        const fireAndForget = [
+            ['EventResource.ping()', () => EventResource.ping()],
+            ['EventResource.trackEvent({name})', () => EventResource.trackEvent({name: 'page_view'})],
+        ];
+
         const streams = [
             ['HelloResource.helloMulti()', () => HelloResource.helloMulti()],
             ['HelloResource.helloMulti({name})', () => HelloResource.helloMulti({name: 'Stream'})],
@@ -394,6 +409,15 @@ class JsonRpcApp extends LitElement {
                         ${securedCalls.map(([label, fn]) =>
                             html`<button ?disabled=${!this._connected}
                                          @click=${() => this._call(label, fn)}>${label}</button>`
+                        )}
+                    </div>
+
+                    <h2>Fire-and-Forget (void methods)</h2>
+                    <label>Notifications — no response expected</label>
+                    <div class="quick-methods">
+                        ${fireAndForget.map(([label, fn]) =>
+                            html`<button ?disabled=${!this._connected}
+                                         @click=${() => this._notify(label, fn)}>${label}</button>`
                         )}
                     </div>
 


### PR DESCRIPTION
The JS client now has a `notify(method, params)` method that sends JSON-RPC notifications (no `id`, no response). The typed proxy generator uses `client.notify()` for void methods instead of `client.call()`, pairing naturally with the inbound notification support added in #141 and void method support from #143.

**JS client** — `notify()` sends fire-and-forget messages. Throws if WebSocket is not connected.

**Proxy generation** — `isVoidReturnType()` detects void methods at build time; `jsClientMethod()` maps return types to the correct client method (`call` / `subscribe` / `notify`). Overload validation ensures all overloads agree on their category.

**Sample app** — New `EventResource` with `ping()` and `trackEvent(String)` void methods, plus a "Fire-and-Forget" section in the tester UI.

**Docs** — Added void method and notification sections to the JavaScript client guide.