### PR TITLE
Add @JsonRPCIgnore annotation to exclude methods from endpoints

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -73,6 +73,7 @@ import io.smallrye.common.annotation.RunOnVirtualThread;
 public class JsonRPCProcessor {
     private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(JsonRPCProcessor.class);
     private static final DotName JSON_RPC_API = DotName.createSimple("io.quarkiverse.jsonrpc.api.JsonRPCApi");
+    private static final DotName JSON_RPC_IGNORE = DotName.createSimple("io.quarkiverse.jsonrpc.api.JsonRPCIgnore");
     private static final Pattern JS_IDENTIFIER = Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$]*$");
     private static final Set<String> JS_RESERVED_WORDS = Set.of(
             "break", "case", "catch", "class", "const", "continue", "debugger", "default",
@@ -125,6 +126,9 @@ public class JsonRPCProcessor {
             for (MethodInfo method : methods) {
                 if (!method.name().equals(CONSTRUCTOR)) { // Ignore constructor
                     if (Modifier.isPublic(method.flags())) { // Only allow public methods
+                        if (method.hasAnnotation(JSON_RPC_IGNORE)) {
+                            continue;
+                        }
                         if (method.hasAnnotation(Blocking.class) && method.hasAnnotation(NonBlocking.class)) {
                             throw new IllegalArgumentException(
                                     "Method " + classInfo.name() + "." + method.name()

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/HelloResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/HelloResource.java
@@ -3,6 +3,7 @@ package io.quarkiverse.jsonrpc.app;
 import java.time.Duration;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.quarkiverse.jsonrpc.api.JsonRPCIgnore;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
@@ -78,5 +79,10 @@ public class HelloResource {
     public Multi<String> helloMulti(String name, String surname) {
         return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
                 .onItem().transform(n -> "(" + n + ") " + hello(name, surname));
+    }
+
+    @JsonRPCIgnore
+    public String ignoredMethod() {
+        return "This should not be exposed";
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
@@ -30,6 +30,16 @@ public class JsonRpcParent {
     @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
+    protected JsonObject getJsonRpcRawResponse(String providedInput) throws Exception {
+        int id = count.incrementAndGet();
+        return jsonRpcRawResponse(id, (ws, queue) -> {
+            ws.textMessageHandler(msg -> {
+                queue.add(msg);
+            });
+            ws.writeTextMessage(getJsonRPCRequest(id, providedInput, Map.of()));
+        });
+    }
+
     protected String getJsonRpcResponse(String providedInput) throws Exception {
         return getJsonRpcResponse(providedInput, String.class);
     }
@@ -65,6 +75,32 @@ public class JsonRpcParent {
             });
             ws.writeTextMessage(getJsonRPCRequest(id, providedInput, params));
         });
+    }
+
+    private JsonObject jsonRpcRawResponse(int expectedId, BiConsumer<WebSocket, Queue<String>> action)
+            throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+            client
+                    .connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            action.accept(ws, message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            JsonObject jsonResponse = Json.decodeValue(response, JsonObject.class);
+            int id = jsonResponse.getInteger("id");
+            Assertions.assertEquals(expectedId, id);
+            return jsonResponse;
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/NormalJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/NormalJsonRpcTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkiverse.jsonrpc.app.HelloResource;
 import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
 
 public class NormalJsonRpcTest extends JsonRpcParent {
 
@@ -135,6 +136,14 @@ public class NormalJsonRpcTest extends JsonRpcParent {
     public void testHelloUniBlockingWithTwoParamsPosition() throws Exception {
         String result = getJsonRpcResponse("HelloResource#helloUniBlocking", new String[] { "Christina", "Storm" });
         Assertions.assertTrue(result.startsWith("Hello Christina Storm [executor-thread-"));
+    }
+
+    @Test
+    public void testIgnoredMethodNotExposed() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("HelloResource#ignoredMethod");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected an error response for ignored method");
+        Assertions.assertEquals(-32601, error.getInteger("code"));
     }
 
 }

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -58,7 +58,32 @@ The following rules apply when the extension scans your class:
 - Only **public** methods are exposed.
 - Constructors and static methods are ignored.
 - Private and package-private methods are ignored.
+- Methods annotated with `@JsonRPCIgnore` are excluded (see <<ignoring-methods>> below).
 - Methods may return any type, including `void` (see <<void-methods>> below).
+
+[#ignoring-methods]
+== Ignoring Methods
+
+Annotate a public method with `@JsonRPCIgnore` to exclude it from JSON-RPC registration. The method remains public and usable from Java (for example, by CDI or other beans), but it will not be exposed as a JSON-RPC endpoint and will not appear in the generated JavaScript client proxy:
+
+[source,java]
+----
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.quarkiverse.jsonrpc.api.JsonRPCIgnore;
+
+@JsonRPCApi
+public class OrderService {
+
+    public Order getOrder(String id) {
+        return findOrder(id);
+    }
+
+    @JsonRPCIgnore
+    public void recalculateTotals() {
+        // Public for CDI, but not a JSON-RPC endpoint
+    }
+}
+----
 
 == CDI Integration
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCIgnore.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCIgnore.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.jsonrpc.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Excludes a public method from being registered as a JSON-RPC endpoint.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface JsonRPCIgnore {
+}


### PR DESCRIPTION
Sometimes a method on a `@JsonRPCApi` class needs to stay public (for CDI injection or other framework usage) but should not be exposed as a JSON-RPC endpoint. The new `@JsonRPCIgnore` annotation lets you opt out individual methods — the processor skips them during build-time scanning, so they don't appear in the method registry or the generated JavaScript client proxy.

Closes #145