### PR TITLE
Add error data field and custom exception-to-error mapping

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -32,6 +32,7 @@ import org.jboss.jandex.Type;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCBroadcaster;
+import io.quarkiverse.jsonrpc.api.JsonRPCExceptionMapper;
 import io.quarkiverse.jsonrpc.deployment.config.JsonRPCConfig;
 import io.quarkiverse.jsonrpc.runtime.JsonRPCRecorder;
 import io.quarkiverse.jsonrpc.runtime.JsonRPCRouter;
@@ -45,6 +46,7 @@ import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -94,6 +96,11 @@ public class JsonRPCProcessor {
         // Make ArC discover the beans marked with the @JsonRPCApi qualifier
         beanDefiningAnnotationProducer
                 .produce(new BeanDefiningAnnotationBuildItem(JSON_RPC_API, BuiltinScope.SINGLETON.getName()));
+    }
+
+    @BuildStep
+    UnremovableBeanBuildItem keepExceptionMappers() {
+        return UnremovableBeanBuildItem.beanTypes(JsonRPCExceptionMapper.class);
     }
 
     @BuildStep

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ExceptionMapperResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ExceptionMapperResource.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.app;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.mutiny.Multi;
 
 @JsonRPCApi
 public class ExceptionMapperResource {
@@ -11,5 +12,13 @@ public class ExceptionMapperResource {
 
     public String unmappedException() {
         throw new IllegalStateException("something went wrong");
+    }
+
+    public String mapperThrows() {
+        throw new MapperBrokenException("trigger broken mapper");
+    }
+
+    public Multi<String> failingStream(String orderId) {
+        return Multi.createFrom().failure(new OrderNotFoundException(orderId));
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ExceptionMapperResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ExceptionMapperResource.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class ExceptionMapperResource {
+
+    public String orderLookup(String orderId) {
+        throw new OrderNotFoundException(orderId);
+    }
+
+    public String unmappedException() {
+        throw new IllegalStateException("something went wrong");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/MapperBrokenException.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/MapperBrokenException.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.jsonrpc.app;
+
+public class MapperBrokenException extends RuntimeException {
+
+    public MapperBrokenException(String message) {
+        super(message);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/OrderNotFoundException.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/OrderNotFoundException.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.jsonrpc.app;
+
+public class OrderNotFoundException extends RuntimeException {
+
+    private final String orderId;
+
+    public OrderNotFoundException(String orderId) {
+        super("Order not found: " + orderId);
+        this.orderId = orderId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/TestExceptionMapper.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/TestExceptionMapper.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.jsonrpc.app;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCError;
+import io.quarkiverse.jsonrpc.api.JsonRPCExceptionMapper;
+
+@ApplicationScoped
+public class TestExceptionMapper implements JsonRPCExceptionMapper {
+
+    @Override
+    public JsonRPCError mapException(Throwable exception) {
+        if (exception instanceof OrderNotFoundException e) {
+            return new JsonRPCError(-40001, "Order not found",
+                    Map.of("orderId", e.getOrderId()));
+        }
+        return null;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/TestExceptionMapper.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/TestExceptionMapper.java
@@ -12,6 +12,9 @@ public class TestExceptionMapper implements JsonRPCExceptionMapper {
 
     @Override
     public JsonRPCError mapException(Throwable exception) {
+        if (exception instanceof MapperBrokenException) {
+            throw new RuntimeException("mapper bug");
+        }
         if (exception instanceof OrderNotFoundException e) {
             return new JsonRPCError(-40001, "Order not found",
                     Map.of("orderId", e.getOrderId()));

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ExceptionMapperJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ExceptionMapperJsonRpcTest.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.ExceptionMapperResource;
+import io.quarkiverse.jsonrpc.app.OrderNotFoundException;
+import io.quarkiverse.jsonrpc.app.TestExceptionMapper;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ExceptionMapperJsonRpcTest extends JsonRpcParent {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ExceptionMapperResource.class, OrderNotFoundException.class, TestExceptionMapper.class);
+            });
+
+    @Test
+    public void testCustomExceptionMappedWithCodeMessageAndData() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("ExceptionMapperResource#orderLookup",
+                Map.of("orderId", "ABC-123"));
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response");
+        Assertions.assertEquals(-40001, error.getInteger("code"));
+        Assertions.assertEquals("Order not found", error.getString("message"));
+
+        JsonObject data = error.getJsonObject("data");
+        Assertions.assertNotNull(data, "Expected data field in error response");
+        Assertions.assertEquals("ABC-123", data.getString("orderId"));
+    }
+
+    @Test
+    public void testUnmappedExceptionFallsBackToInternalError() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("ExceptionMapperResource#unmappedException");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response");
+        Assertions.assertEquals(-32603, error.getInteger("code"));
+        Assertions.assertTrue(error.getString("message").contains("something went wrong"));
+        Assertions.assertNull(error.getValue("data"), "Expected no data field for unmapped exception");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ExceptionMapperJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ExceptionMapperJsonRpcTest.java
@@ -1,12 +1,16 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkiverse.jsonrpc.app.ExceptionMapperResource;
+import io.quarkiverse.jsonrpc.app.MapperBrokenException;
 import io.quarkiverse.jsonrpc.app.OrderNotFoundException;
 import io.quarkiverse.jsonrpc.app.TestExceptionMapper;
 import io.quarkus.test.QuarkusUnitTest;
@@ -17,7 +21,8 @@ public class ExceptionMapperJsonRpcTest extends JsonRpcParent {
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
-                root.addClasses(ExceptionMapperResource.class, OrderNotFoundException.class, TestExceptionMapper.class);
+                root.addClasses(ExceptionMapperResource.class, OrderNotFoundException.class,
+                        MapperBrokenException.class, TestExceptionMapper.class);
             });
 
     @Test
@@ -42,5 +47,65 @@ public class ExceptionMapperJsonRpcTest extends JsonRpcParent {
         Assertions.assertEquals(-32603, error.getInteger("code"));
         Assertions.assertTrue(error.getString("message").contains("something went wrong"));
         Assertions.assertNull(error.getValue("data"), "Expected no data field for unmapped exception");
+    }
+
+    @Test
+    public void testBrokenMapperFallsBackToInternalError() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("ExceptionMapperResource#mapperThrows");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response");
+        Assertions.assertEquals(-32603, error.getInteger("code"));
+        Assertions.assertTrue(error.getString("message").contains("trigger broken mapper"));
+    }
+
+    @Test
+    public void testSubscriptionErrorUsesCustomMapper() throws Exception {
+        var client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            CompletableFuture<Void> connected = new CompletableFuture<>();
+            JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 99,
+                    "method", "ExceptionMapperResource#failingStream",
+                    "params", JsonObject.of("orderId", "XYZ-789"));
+
+            client.connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(request.encode());
+                            connected.complete(null);
+                        } else {
+                            connected.completeExceptionally(r.cause());
+                        }
+                    });
+
+            connected.get(5, TimeUnit.SECONDS);
+
+            // Message 1: ack with subscription ID
+            String ackMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(ackMsg, "Expected ack message");
+            JsonObject ack = new JsonObject(ackMsg);
+            Assertions.assertEquals(99, ack.getInteger("id"));
+            String subscriptionId = ack.getString("result");
+            Assertions.assertNotNull(subscriptionId, "Ack result should be a subscription ID");
+
+            // Message 2: error notification with custom mapper code/data
+            String errMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(errMsg, "Expected error notification");
+            JsonObject errJson = new JsonObject(errMsg);
+            Assertions.assertEquals("subscription", errJson.getString("method"));
+            JsonObject errParams = errJson.getJsonObject("params");
+            Assertions.assertEquals(subscriptionId, errParams.getString("subscription"));
+            JsonObject error = errParams.getJsonObject("error");
+            Assertions.assertNotNull(error, "Expected error object in params");
+            Assertions.assertEquals(-40001, error.getInteger("code"));
+            Assertions.assertEquals("Order not found", error.getString("message"));
+            JsonObject data = error.getJsonObject("data");
+            Assertions.assertNotNull(data, "Expected data field in subscription error");
+            Assertions.assertEquals("XYZ-789", data.getString("orderId"));
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
@@ -30,6 +30,20 @@ public class JsonRpcParent {
     @TestHTTPResource("json-rpc")
     URI jsonRpcUri;
 
+    protected JsonObject getJsonRpcRawResponse(String providedInput) throws Exception {
+        return getJsonRpcRawResponse(providedInput, Map.of());
+    }
+
+    protected JsonObject getJsonRpcRawResponse(String providedInput, Map<String, Object> params) throws Exception {
+        int id = count.incrementAndGet();
+        return jsonRpcRawResponse(id, (ws, queue) -> {
+            ws.textMessageHandler(msg -> {
+                queue.add(msg);
+            });
+            ws.writeTextMessage(getJsonRPCRequest(id, providedInput, params));
+        });
+    }
+
     protected String getJsonRpcResponse(String providedInput) throws Exception {
         return getJsonRpcResponse(providedInput, String.class);
     }
@@ -65,6 +79,32 @@ public class JsonRpcParent {
             });
             ws.writeTextMessage(getJsonRPCRequest(id, providedInput, params));
         });
+    }
+
+    private JsonObject jsonRpcRawResponse(int expectedId, BiConsumer<WebSocket, Queue<String>> action)
+            throws Exception {
+        WebSocketClient client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
+            client
+                    .connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            WebSocket ws = r.result();
+                            action.accept(ws, message);
+                        } else {
+                            throw new IllegalStateException(r.cause());
+                        }
+                    });
+
+            String response = message.poll(10, TimeUnit.SECONDS);
+            JsonObject jsonResponse = Json.decodeValue(response, JsonObject.class);
+            int id = jsonResponse.getInteger("id");
+            Assertions.assertEquals(expectedId, id);
+            return jsonResponse;
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCError.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCError.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.jsonrpc.api;
+
+public class JsonRPCError {
+
+    private final int code;
+    private final String message;
+    private final Object data;
+
+    public JsonRPCError(int code, String message) {
+        this(code, message, null);
+    }
+
+    public JsonRPCError(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Object getData() {
+        return data;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCError.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCError.java
@@ -1,30 +1,8 @@
 package io.quarkiverse.jsonrpc.api;
 
-public class JsonRPCError {
-
-    private final int code;
-    private final String message;
-    private final Object data;
+public record JsonRPCError(int code, String message, Object data) {
 
     public JsonRPCError(int code, String message) {
         this(code, message, null);
-    }
-
-    public JsonRPCError(int code, String message, Object data) {
-        this.code = code;
-        this.message = message;
-        this.data = data;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public Object getData() {
-        return data;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCExceptionMapper.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.jsonrpc.api;
+
+/**
+ * Maps exceptions thrown by JSON-RPC methods to structured error responses.
+ *
+ * <p>
+ * Implement this interface as a CDI bean to customize how exceptions are translated
+ * into JSON-RPC error codes, messages, and optional data. Return {@code null} to
+ * indicate that this mapper does not handle the given exception.
+ *
+ * <pre>
+ * &#64;ApplicationScoped
+ * public class MyExceptionMapper implements JsonRPCExceptionMapper {
+ *
+ *     &#64;Override
+ *     public JsonRPCError mapException(Throwable exception) {
+ *         if (exception instanceof OrderNotFoundException e) {
+ *             return new JsonRPCError(-40001, "Order not found", e.getOrderId());
+ *         }
+ *         return null;
+ *     }
+ * }
+ * </pre>
+ */
+public interface JsonRPCExceptionMapper {
+
+    /**
+     * Map the given exception to a JSON-RPC error, or return {@code null}
+     * to let the next mapper (or built-in logic) handle it.
+     */
+    JsonRPCError mapException(Throwable exception);
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 
+import io.quarkiverse.jsonrpc.api.JsonRPCError;
+import io.quarkiverse.jsonrpc.api.JsonRPCExceptionMapper;
 import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCKeys;
@@ -58,6 +60,9 @@ public class JsonRPCRouter {
 
     private volatile CurrentIdentityAssociation identityAssociation;
     private volatile boolean identityAssociationUnavailable;
+
+    private volatile List<JsonRPCExceptionMapper> exceptionMappers;
+    private volatile boolean exceptionMappersResolved;
 
     // Map json-rpc method to java in runtime classpath
     private final Map<String, ReflectionInfo> jsonRpcToJava = new HashMap<>();
@@ -491,11 +496,14 @@ public class JsonRPCRouter {
                             .with(
                                     item -> codec.writeSubscriptionItem(s, subscriptionId, item),
                                     failure -> {
+                                        Throwable cause = unwrap(failure);
                                         if (m != null) {
                                             m.recordSubscriptionError(methodName);
                                             m.subscriptionEnded();
                                         }
-                                        codec.writeSubscriptionError(s, subscriptionId, methodName, unwrap(failure));
+                                        LOG.error("Error in JsonRPC subscription", cause);
+                                        codec.writeSubscriptionError(s, subscriptionId,
+                                                resolveError(methodName, cause));
                                         subs.remove(subscriptionId);
                                     },
                                     () -> {
@@ -550,21 +558,42 @@ public class JsonRPCRouter {
         }
     }
 
-    private static JsonRPCResponse<?> errorResponse(JsonNode id, String methodName, Throwable exception) {
-        int code = resolveErrorCode(exception);
+    private JsonRPCResponse<?> errorResponse(JsonNode id, String methodName, Throwable exception) {
+        JsonRPCResponse.Error error = resolveError(methodName, exception);
         LOG.error("Error in JsonRPC Call", exception);
-        return new JsonRPCResponse<>(id,
-                new JsonRPCResponse.Error(code, "Method [" + methodName + "] failed: " + exception.getMessage()));
+        return new JsonRPCResponse<>(id, error);
     }
 
-    private static int resolveErrorCode(Throwable exception) {
+    private JsonRPCResponse.Error resolveError(String methodName, Throwable exception) {
+        for (JsonRPCExceptionMapper mapper : getExceptionMappers()) {
+            JsonRPCError mapped = mapper.mapException(exception);
+            if (mapped != null) {
+                return new JsonRPCResponse.Error(mapped.getCode(), mapped.getMessage(), mapped.getData());
+            }
+        }
         if (exception instanceof io.quarkus.security.UnauthorizedException) {
-            return JsonRPCKeys.UNAUTHORIZED;
+            return new JsonRPCResponse.Error(JsonRPCKeys.UNAUTHORIZED,
+                    "Method [" + methodName + "] failed: " + exception.getMessage());
         }
         if (exception instanceof io.quarkus.security.ForbiddenException) {
-            return JsonRPCKeys.FORBIDDEN;
+            return new JsonRPCResponse.Error(JsonRPCKeys.FORBIDDEN,
+                    "Method [" + methodName + "] failed: " + exception.getMessage());
         }
-        return JsonRPCKeys.INTERNAL_ERROR;
+        return new JsonRPCResponse.Error(JsonRPCKeys.INTERNAL_ERROR,
+                "Method [" + methodName + "] failed: " + exception.getMessage());
+    }
+
+    private List<JsonRPCExceptionMapper> getExceptionMappers() {
+        if (!exceptionMappersResolved) {
+            try {
+                exceptionMappers = Arc.container().select(JsonRPCExceptionMapper.class)
+                        .stream().toList();
+            } catch (jakarta.enterprise.inject.UnsatisfiedResolutionException e) {
+                exceptionMappers = List.of();
+            }
+            exceptionMappersResolved = true;
+        }
+        return exceptionMappers;
     }
 
     private Uni<JsonRPCResponse<?>> handleUnsubscribe(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -62,7 +62,6 @@ public class JsonRPCRouter {
     private volatile boolean identityAssociationUnavailable;
 
     private volatile List<JsonRPCExceptionMapper> exceptionMappers;
-    private volatile boolean exceptionMappersResolved;
 
     // Map json-rpc method to java in runtime classpath
     private final Map<String, ReflectionInfo> jsonRpcToJava = new HashMap<>();
@@ -566,9 +565,14 @@ public class JsonRPCRouter {
 
     private JsonRPCResponse.Error resolveError(String methodName, Throwable exception) {
         for (JsonRPCExceptionMapper mapper : getExceptionMappers()) {
-            JsonRPCError mapped = mapper.mapException(exception);
-            if (mapped != null) {
-                return new JsonRPCResponse.Error(mapped.getCode(), mapped.getMessage(), mapped.getData());
+            try {
+                JsonRPCError mapped = mapper.mapException(exception);
+                if (mapped != null) {
+                    return new JsonRPCResponse.Error(mapped.code(), mapped.message(), mapped.data());
+                }
+            } catch (Exception e) {
+                LOG.warnf(e, "Exception mapper %s threw while handling %s",
+                        mapper.getClass().getName(), exception.getClass().getName());
             }
         }
         if (exception instanceof io.quarkus.security.UnauthorizedException) {
@@ -584,16 +588,13 @@ public class JsonRPCRouter {
     }
 
     private List<JsonRPCExceptionMapper> getExceptionMappers() {
-        if (!exceptionMappersResolved) {
-            try {
-                exceptionMappers = Arc.container().select(JsonRPCExceptionMapper.class)
-                        .stream().toList();
-            } catch (jakarta.enterprise.inject.UnsatisfiedResolutionException e) {
-                exceptionMappers = List.of();
-            }
-            exceptionMappersResolved = true;
+        List<JsonRPCExceptionMapper> local = exceptionMappers;
+        if (local == null) {
+            local = Arc.container().select(JsonRPCExceptionMapper.class)
+                    .stream().toList();
+            exceptionMappers = local;
         }
-        return exceptionMappers;
+        return local;
     }
 
     private Uni<JsonRPCResponse<?>> handleUnsubscribe(JsonRPCRequest jsonRpcRequest, ServerWebSocket s) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -53,12 +53,13 @@ public class JsonRPCCodec {
         writeNotification(socket, new JsonRPCNotification(JsonRPCKeys.SUBSCRIPTION, params));
     }
 
-    public void writeSubscriptionError(ServerWebSocket socket, String subscriptionId, String methodName,
-            Throwable exception) {
-        LOG.error("Error in JsonRPC subscription", exception);
+    public void writeSubscriptionError(ServerWebSocket socket, String subscriptionId, JsonRPCResponse.Error error) {
         Map<String, Object> errorDetail = new LinkedHashMap<>();
-        errorDetail.put(JsonRPCKeys.CODE, JsonRPCKeys.INTERNAL_ERROR);
-        errorDetail.put(JsonRPCKeys.MESSAGE, "Method [" + methodName + "] failed: " + exception.getMessage());
+        errorDetail.put(JsonRPCKeys.CODE, error.code);
+        errorDetail.put(JsonRPCKeys.MESSAGE, error.message);
+        if (error.data != null) {
+            errorDetail.put(JsonRPCKeys.DATA, error.data);
+        }
 
         Map<String, Object> params = new LinkedHashMap<>();
         params.put(JsonRPCKeys.SUBSCRIPTION, subscriptionId);

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCKeys.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCKeys.java
@@ -13,6 +13,7 @@ public interface JsonRPCKeys {
     public static final String METHOD = "method";
     public static final String PARAMS = "params";
     public static final String SUBSCRIPTION = "subscription";
+    public static final String DATA = "data";
     public static final String COMPLETE = "complete";
     public static final String UNSUBSCRIBE = "unsubscribe";
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCResponse.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCResponse.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.jsonrpc.runtime.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class JsonRPCResponse<T> {
@@ -36,10 +37,17 @@ public class JsonRPCResponse<T> {
     public static final class Error {
         public final int code;
         public final String message;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public final Object data;
 
         public Error(int code, String message) {
+            this(code, message, null);
+        }
+
+        public Error(int code, String message, Object data) {
             this.code = code;
             this.message = message;
+            this.data = data;
         }
 
         @Override
@@ -47,6 +55,7 @@ public class JsonRPCResponse<T> {
             return "error {" +
                     "  code=" + code + "," +
                     "  message='" + message + "'" +
+                    (data != null ? ",  data=" + data : "") +
                     "}";
         }
     }


### PR DESCRIPTION
The JSON-RPC 2.0 spec allows an optional `data` field in error responses for structured additional information, but `JsonRPCResponse.Error` only carried `code` and `message`. Additionally, `resolveErrorCode()` in the router hardcoded just two security exception mappings with no user extension point.

This adds both capabilities together since they're naturally complementary — a custom exception mapper returns code, message, and data.

**Error data field** — `JsonRPCResponse.Error` now has an optional `data` field (omitted from JSON when null via `@JsonInclude(NON_NULL)`). This applies to both regular error responses and subscription error notifications.

**Custom exception mappers** — Users implement `JsonRPCExceptionMapper` as a CDI bean. The router consults all registered mappers before falling back to the built-in security exception checks and the default `INTERNAL_ERROR`. Mappers return a `JsonRPCError` (code, message, optional data) or `null` to pass.

```java
@ApplicationScoped
public class MyExceptionMapper implements JsonRPCExceptionMapper {

    @Override
    public JsonRPCError mapException(Throwable exception) {
        if (exception instanceof OrderNotFoundException e) {
            return new JsonRPCError(-40001, "Order not found", Map.of("orderId", e.getOrderId()));
        }
        return null;
    }
}
```

Closes #129, closes #132