### PR TITLE
Add connection lifecycle hooks via CDI events

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -220,6 +220,8 @@ public class JsonRPCProcessor {
         nativeClasses.add(io.quarkiverse.jsonrpc.runtime.model.JsonRPCNotification.class.getName());
         nativeClasses.add(JsonRPCSessions.class.getName());
         nativeClasses.add(JsonRPCBroadcaster.class.getName());
+        nativeClasses.add(io.quarkiverse.jsonrpc.api.JsonRPCConnected.class.getName());
+        nativeClasses.add(io.quarkiverse.jsonrpc.api.JsonRPCDisconnected.class.getName());
 
         // Make sure it's available in native
         reflectiveClassProducer

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ConnectionObserver.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ConnectionObserver.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.jsonrpc.app;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCConnected;
+import io.quarkiverse.jsonrpc.api.JsonRPCDisconnected;
+
+@ApplicationScoped
+public class ConnectionObserver {
+
+    private static final List<String> connectedSessions = new CopyOnWriteArrayList<>();
+    private static final List<String> disconnectedSessions = new CopyOnWriteArrayList<>();
+    private static volatile CountDownLatch disconnectLatch = new CountDownLatch(1);
+
+    void onConnect(@Observes JsonRPCConnected event) {
+        connectedSessions.add(event.sessionId());
+    }
+
+    void onDisconnect(@Observes JsonRPCDisconnected event) {
+        disconnectedSessions.add(event.sessionId());
+        disconnectLatch.countDown();
+    }
+
+    public static List<String> getConnectedSessions() {
+        return connectedSessions;
+    }
+
+    public static List<String> getDisconnectedSessions() {
+        return disconnectedSessions;
+    }
+
+    public static CountDownLatch getDisconnectLatch() {
+        return disconnectLatch;
+    }
+
+    public static void reset() {
+        connectedSessions.clear();
+        disconnectedSessions.clear();
+        disconnectLatch = new CountDownLatch(1);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ConnectionLifecycleTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/ConnectionLifecycleTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.ConnectionObserver;
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConnectionLifecycleTest extends JsonRpcParent {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class, ConnectionObserver.class);
+            });
+
+    @BeforeEach
+    void resetObserver() {
+        ConnectionObserver.reset();
+    }
+
+    @Test
+    public void testConnectEventFired() throws Exception {
+        getJsonRpcResponse("HelloResource#hello", Map.of("name", "Test"));
+
+        Assertions.assertFalse(ConnectionObserver.getConnectedSessions().isEmpty(),
+                "Expected at least one connect event");
+        String sessionId = ConnectionObserver.getConnectedSessions().get(0);
+        Assertions.assertNotNull(sessionId);
+        Assertions.assertFalse(sessionId.isEmpty());
+    }
+
+    @Test
+    public void testDisconnectEventFired() throws Exception {
+        getJsonRpcResponse("HelloResource#hello", Map.of("name", "Test"));
+
+        Assertions.assertTrue(ConnectionObserver.getDisconnectLatch().await(5, TimeUnit.SECONDS),
+                "Expected disconnect event within 5 seconds");
+
+        String sessionId = ConnectionObserver.getDisconnectedSessions().get(0);
+        Assertions.assertNotNull(sessionId);
+        Assertions.assertFalse(sessionId.isEmpty());
+    }
+
+    @Test
+    public void testConnectAndDisconnectSameSessionId() throws Exception {
+        getJsonRpcResponse("HelloResource#hello", Map.of("name", "Test"));
+
+        Assertions.assertTrue(ConnectionObserver.getDisconnectLatch().await(5, TimeUnit.SECONDS),
+                "Expected disconnect event within 5 seconds");
+
+        Assertions.assertEquals(1, ConnectionObserver.getConnectedSessions().size());
+        Assertions.assertEquals(1, ConnectionObserver.getDisconnectedSessions().size());
+        Assertions.assertEquals(
+                ConnectionObserver.getConnectedSessions().get(0),
+                ConnectionObserver.getDisconnectedSessions().get(0));
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 ** xref:guides-broadcasting.adoc[Broadcasting]
 ** xref:guides-security.adoc[Security]
 ** xref:guides-concurrency.adoc[Concurrency & Session Isolation]
+** xref:guides-connection-lifecycle.adoc[Connection Lifecycle Events]
 ** xref:guides-metrics.adoc[Metrics]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 

--- a/docs/modules/ROOT/pages/guides-connection-lifecycle.adoc
+++ b/docs/modules/ROOT/pages/guides-connection-lifecycle.adoc
@@ -1,0 +1,80 @@
+= Connection Lifecycle Events
+
+include::./includes/attributes.adoc[]
+
+The extension fires CDI events when WebSocket clients connect and disconnect. Observe these events to log connections, initialize per-session state, or clean up resources on disconnect.
+
+== Observing Connections
+
+[source,java]
+----
+import io.quarkiverse.jsonrpc.api.JsonRPCConnected;
+import io.quarkiverse.jsonrpc.api.JsonRPCDisconnected;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+@ApplicationScoped
+public class ConnectionObserver {
+
+    void onConnect(@Observes JsonRPCConnected event) {
+        Log.infof("Client connected: %s", event.sessionId());
+    }
+
+    void onDisconnect(@Observes JsonRPCDisconnected event) {
+        Log.infof("Client disconnected: %s", event.sessionId());
+    }
+}
+----
+
+Both events carry a `sessionId()` — the same identifier used by `JsonRPCBroadcaster` to target individual clients.
+
+== Event Timing
+
+`JsonRPCConnected`::
+Fires after session registration and identity setup but *before* message handlers are attached. The socket cannot yet receive JSON-RPC messages during observer execution.
+
+`JsonRPCDisconnected`::
+Fires *after* the session has been fully cleaned up — session removed, identity cleared, subscriptions cancelled. Observers cannot send messages to the disconnecting client.
+
+== Threading
+
+Both events fire on the Vert.x event loop thread. Observers must not perform blocking operations (database calls, HTTP requests, file I/O). If you need to do blocking work in response to a connection event, offload it:
+
+[source,java]
+----
+@ApplicationScoped
+public class ConnectionObserver {
+
+    @Inject
+    Vertx vertx;
+
+    void onConnect(@Observes JsonRPCConnected event) {
+        vertx.executeBlocking(() -> {
+            // blocking work here
+            return null;
+        });
+    }
+}
+----
+
+== Use with Broadcasting
+
+Combine lifecycle events with `JsonRPCBroadcaster` to notify existing clients when someone joins:
+
+[source,java]
+----
+@ApplicationScoped
+public class PresenceObserver {
+
+    @Inject
+    JsonRPCBroadcaster broadcaster;
+
+    void onConnect(@Observes JsonRPCConnected event) {
+        broadcaster.broadcast("userJoined", Map.of("sessionId", event.sessionId()));
+    }
+
+    void onDisconnect(@Observes JsonRPCDisconnected event) {
+        broadcaster.broadcast("userLeft", Map.of("sessionId", event.sessionId()));
+    }
+}
+----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -109,6 +109,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 | xref:guides-concurrency.adoc[Concurrency & Session Isolation]
 | Connection isolation, shared bean instances, threading model, and tuning for production.
 
+| xref:guides-connection-lifecycle.adoc[Connection Lifecycle Events]
+| React to client connect and disconnect via CDI events.
+
 | xref:guides-metrics.adoc[Metrics]
 | Automatic request timing and connection tracking with Micrometer.
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCConnected.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCConnected.java
@@ -2,6 +2,10 @@ package io.quarkiverse.jsonrpc.api;
 
 /**
  * CDI event fired when a new WebSocket client connects to the JSON-RPC endpoint.
+ * The event fires after session registration and identity setup but before message handlers
+ * are attached, so the socket cannot yet receive messages during observer execution.
+ * <p>
+ * This event is fired on the Vert.x event loop thread; observers must not perform blocking operations.
  */
 public record JsonRPCConnected(String sessionId) {
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCConnected.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCConnected.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.jsonrpc.api;
+
+/**
+ * CDI event fired when a new WebSocket client connects to the JSON-RPC endpoint.
+ */
+public record JsonRPCConnected(String sessionId) {
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCDisconnected.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCDisconnected.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.jsonrpc.api;
+
+/**
+ * CDI event fired when a WebSocket client disconnects from the JSON-RPC endpoint.
+ */
+public record JsonRPCDisconnected(String sessionId) {
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCDisconnected.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCDisconnected.java
@@ -2,6 +2,10 @@ package io.quarkiverse.jsonrpc.api;
 
 /**
  * CDI event fired when a WebSocket client disconnects from the JSON-RPC endpoint.
+ * The session is already closed and removed when this event fires; observers cannot send
+ * messages to the disconnecting client.
+ * <p>
+ * This event is fired on the Vert.x event loop thread; observers must not perform blocking operations.
  */
 public record JsonRPCDisconnected(String sessionId) {
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -671,9 +671,10 @@ public class JsonRPCRouter {
         return objects.toArray(Object[]::new);
     }
 
-    private void fireEvent(Object event) {
+    @SuppressWarnings("unchecked")
+    private <T> void fireEvent(T event) {
         try {
-            Arc.container().beanManager().getEvent().select((Class) event.getClass()).fire(event);
+            Arc.container().beanManager().getEvent().select((Class<T>) event.getClass()).fire(event);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to fire %s event", event.getClass().getSimpleName());
         }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 
+import io.quarkiverse.jsonrpc.api.JsonRPCConnected;
+import io.quarkiverse.jsonrpc.api.JsonRPCDisconnected;
 import io.quarkiverse.jsonrpc.api.JsonRPCError;
 import io.quarkiverse.jsonrpc.api.JsonRPCExceptionMapper;
 import io.quarkiverse.jsonrpc.runtime.model.ExecutionMode;
@@ -235,7 +237,7 @@ public class JsonRPCRouter {
     }
 
     public void addSocket(ServerWebSocket socket, SecurityIdentity identity) {
-        sessions.addSession(socket);
+        String sessionId = sessions.addSession(socket);
         JsonRPCMetricsHandler m = metrics();
         if (m != null) {
             m.connectionOpened();
@@ -243,6 +245,7 @@ public class JsonRPCRouter {
         if (identity != null && !identity.isAnonymous()) {
             socketIdentities.put(socket, identity);
         }
+        fireEvent(new JsonRPCConnected(sessionId));
         socket.textMessageHandler((e) -> {
             try {
                 JsonNode jsonNode;
@@ -286,6 +289,7 @@ public class JsonRPCRouter {
             }
         });
         socket.closeHandler((e) -> {
+            String closedSessionId = sessions.getSessionId(socket);
             sessions.removeSession(socket);
             socketIdentities.remove(socket);
             JsonRPCMetricsHandler mc = metrics();
@@ -304,6 +308,9 @@ public class JsonRPCRouter {
                         mc.subscriptionEnded();
                     }
                 }
+            }
+            if (closedSessionId != null) {
+                fireEvent(new JsonRPCDisconnected(closedSessionId));
             }
         });
     }
@@ -662,5 +669,13 @@ public class JsonRPCRouter {
             idx++;
         }
         return objects.toArray(Object[]::new);
+    }
+
+    private void fireEvent(Object event) {
+        try {
+            Arc.container().beanManager().getEvent().select((Class) event.getClass()).fire(event);
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to fire %s event", event.getClass().getSimpleName());
+        }
     }
 }


### PR DESCRIPTION
Application code can now react to WebSocket connection lifecycle by observing `JsonRPCConnected` and `JsonRPCDisconnected` CDI events. This enables use cases like logging/auditing connections, initializing per-session state, cleaning up resources on disconnect, and sending welcome messages.

```java
@ApplicationScoped
public class ConnectionObserver {

    void onConnect(@Observes JsonRPCConnected event) {
        Log.infof("Client connected: %s", event.sessionId());
    }

    void onDisconnect(@Observes JsonRPCDisconnected event) {
        Log.infof("Client disconnected: %s", event.sessionId());
    }
}
```

Events are fired from `JsonRPCRouter.addSocket()` using `Arc.container().beanManager().getEvent()`, consistent with the existing pattern of accessing CDI from synthetic beans. The connect event fires after session registration and identity setup but before message handlers are attached, so observers run before the socket can receive messages. The disconnect event fires after full cleanup (session removal, identity cleanup, subscription cancellation).

Both events fire on the Vert.x event loop thread — Javadoc on the event records warns observers not to block. A new documentation page covers usage, event timing, threading considerations (with an `executeBlocking` workaround example), and a broadcasting integration example.

Closes #134