### PR TITLE
Add configurable timeout for JSON-RPC method execution

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/FaultToleranceTimeoutResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/FaultToleranceTimeoutResource.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.jsonrpc.app;
+
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class FaultToleranceTimeoutResource {
+
+    @Timeout(1000)
+    public String slow() throws InterruptedException {
+        Thread.sleep(5000);
+        return "done";
+    }
+
+    public String fast() {
+        return "Hello " + Thread.currentThread().getName();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/TimeoutResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/TimeoutResource.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi
+public class TimeoutResource {
+
+    public String slow() throws InterruptedException {
+        Thread.sleep(5000);
+        return "done";
+    }
+
+    public String fast() {
+        return "Hello " + Thread.currentThread().getName();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/FaultToleranceTimeoutJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/FaultToleranceTimeoutJsonRpcTest.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.FaultToleranceTimeoutResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class FaultToleranceTimeoutJsonRpcTest extends JsonRpcParent {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(FaultToleranceTimeoutResource.class));
+
+    @Test
+    public void testSmallRyeFaultToleranceTimeout() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("FaultToleranceTimeoutResource#slow");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response for @Timeout method");
+        Assertions.assertEquals(-32002, error.getInteger("code"));
+        Assertions.assertTrue(error.getString("message").contains("timed out"));
+    }
+
+    @Test
+    public void testFastMethodSucceeds() throws Exception {
+        String result = getJsonRpcResponse("FaultToleranceTimeoutResource#fast");
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.startsWith("Hello "));
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/TimeoutJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/TimeoutJsonRpcTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.TimeoutResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class TimeoutJsonRpcTest extends JsonRpcParent {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(TimeoutResource.class))
+            .overrideConfigKey("quarkus.json-rpc.method-timeout", "1s");
+
+    @Test
+    public void testSlowMethodTimesOut() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("TimeoutResource#slow");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response for timed-out method");
+        Assertions.assertEquals(-32002, error.getInteger("code"));
+        Assertions.assertTrue(error.getString("message").contains("timed out"));
+    }
+
+    @Test
+    public void testFastMethodSucceeds() throws Exception {
+        String result = getJsonRpcResponse("TimeoutResource#fast");
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.startsWith("Hello "));
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -10,6 +10,7 @@
 ** xref:guides-security.adoc[Security]
 ** xref:guides-concurrency.adoc[Concurrency & Session Isolation]
 ** xref:guides-connection-lifecycle.adoc[Connection Lifecycle Events]
+** xref:guides-timeouts.adoc[Timeouts]
 ** xref:guides-metrics.adoc[Metrics]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 

--- a/docs/modules/ROOT/pages/guides-timeouts.adoc
+++ b/docs/modules/ROOT/pages/guides-timeouts.adoc
@@ -1,0 +1,160 @@
+= Timeouts
+:description: Configuring timeouts for JSON-RPC method execution.
+
+include::./includes/attributes.adoc[]
+
+By default, JSON-RPC method calls have no timeout — if a method hangs, it ties up a thread indefinitely and the client never receives a response. You can guard against this with a global timeout, per-method timeouts via MicroProfile Fault Tolerance, or both.
+
+== Global Timeout
+
+Set a global timeout that applies to all non-streaming methods:
+
+[source,properties]
+----
+quarkus.json-rpc.method-timeout=30s
+----
+
+Any method that does not complete within this duration receives a timeout error response. Streaming methods (`Multi<T>` and `Flow.Publisher<T>`) are not affected — they are long-lived subscriptions where a global timeout does not apply.
+
+The timeout is disabled by default. Use standard Quarkus duration format (`30s`, `2m`, `500ms`, etc.).
+
+== Per-Method Timeout with MicroProfile Fault Tolerance
+
+For fine-grained control, use the `@Timeout` annotation from https://download.eclipse.org/microprofile/microprofile-fault-tolerance-3.0/microprofile-fault-tolerance-spec-3.0.html[MicroProfile Fault Tolerance]. This works because `@JsonRPCApi` classes are CDI beans, and Quarkus SmallRye Fault Tolerance applies its interceptors through the CDI proxy — exactly as it does for REST endpoints or any other CDI bean.
+
+Add the extension to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+</dependency>
+----
+
+Then annotate individual methods:
+
+[source,java]
+----
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@JsonRPCApi
+public class MyService {
+
+    @Timeout(5000) // <1>
+    public String slowOperation() {
+        return expensiveComputation();
+    }
+
+    public String fastOperation() { // <2>
+        return "instant";
+    }
+}
+----
+<1> Times out after 5 seconds.
+<2> No per-method timeout — uses the global timeout if configured, otherwise no limit.
+
+=== Combining with Other Fault Tolerance Annotations
+
+Since the integration works through standard CDI interceptors, all MicroProfile Fault Tolerance annotations work on `@JsonRPCApi` methods — not just `@Timeout`. You can combine them as you would on any CDI bean:
+
+[source,java]
+----
+@JsonRPCApi
+public class ResilientService {
+
+    @Timeout(3000)
+    @Retry(maxRetries = 2)
+    @Fallback(fallbackMethod = "fallbackLookup")
+    public String lookup(String id) {
+        return externalService.fetch(id);
+    }
+
+    String fallbackLookup(String id) {
+        return cachedData.get(id);
+    }
+}
+----
+
+== Combining Global and Per-Method Timeouts
+
+Both mechanisms can be active at the same time. Per-method `@Timeout` fires first (at the CDI interceptor level, before the router's timeout), so it takes precedence for methods that have it:
+
+[cols="2,2,2"]
+|===
+| Method | `@Timeout` | Effective timeout
+
+| `slowOperation()`
+| `@Timeout(5000)`
+| 5 seconds (from Fault Tolerance)
+
+| `fastOperation()`
+| _(none)_
+| 30 seconds (from global config)
+|===
+
+The global timeout acts as a safety net — it catches methods that don't have `@Timeout` but still hang unexpectedly.
+
+== Error Response
+
+When a timeout occurs (from either mechanism), the extension returns a JSON-RPC error with code `-32002`:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32002,
+    "message": "Method [MyService#slowOperation] timed out"
+  }
+}
+----
+
+This code is in the JSON-RPC 2.0 server-defined range (`-32000` to `-32099`), alongside the security error codes:
+
+[cols="1,1,2"]
+|===
+| Code | Name | Meaning
+
+| `-32000`
+| Unauthorized
+| Authentication required but not provided.
+
+| `-32001`
+| Forbidden
+| Authenticated but not authorized.
+
+| `-32002`
+| Timeout
+| Method did not complete within the configured time limit.
+|===
+
+== Custom Error Handling
+
+If you need custom timeout error responses, you can use a `JsonRPCExceptionMapper` to intercept the timeout exception:
+
+[source,java]
+----
+import io.quarkiverse.jsonrpc.api.JsonRPCError;
+import io.quarkiverse.jsonrpc.api.JsonRPCExceptionMapper;
+
+@ApplicationScoped
+public class TimeoutMapper implements JsonRPCExceptionMapper {
+
+    @Override
+    public JsonRPCError mapException(Throwable exception) {
+        if (exception.getClass().getName().contains("TimeoutException")) {
+            return new JsonRPCError(-50001, "Service is busy, please try again later");
+        }
+        return null; // let other mappers or the default handler deal with it
+    }
+}
+----
+
+Exception mappers are consulted before the built-in timeout handling, so your mapper takes precedence.
+
+== Notes
+
+* The global timeout returns an error to the client promptly, but it does not guarantee cancellation of the underlying work. A blocking method may continue running on its worker thread until it completes naturally. This matches the behavior of MicroProfile Fault Tolerance's `@Timeout`.
+* Streaming methods (`Multi<T>`, `Flow.Publisher<T>`) are excluded from the global timeout. For streaming, consider using Mutiny's built-in operators like `Multi.ifNoItem().after(duration).fail()` within your method implementation.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -76,6 +76,9 @@ Complex types are serialized and deserialized automatically via Jackson, includi
 Security::
 Secure your endpoints with standard Jakarta security annotations (`@RolesAllowed`, `@Authenticated`, etc.) or Quarkus HTTP auth policies — opt-in, no changes needed for unsecured use cases.
 
+Timeouts::
+Protect against hanging methods with a global timeout or per-method `@Timeout` via MicroProfile Fault Tolerance.
+
 JavaScript client::
 Optionally generate a typed JavaScript proxy for all your endpoints, ready to import from Quarkus Web Bundler or any ES module environment.
 
@@ -111,6 +114,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 
 | xref:guides-connection-lifecycle.adoc[Connection Lifecycle Events]
 | React to client connect and disconnect via CDI events.
+
+| xref:guides-timeouts.adoc[Timeouts]
+| Protect against hanging methods with global or per-method timeouts.
 
 | xref:guides-metrics.adoc[Metrics]
 | Automatic request timing and connection tracking with Micrometer.

--- a/docs/modules/ROOT/pages/reference-configuration.adoc
+++ b/docs/modules/ROOT/pages/reference-configuration.adoc
@@ -2,6 +2,6 @@
 
 include::./includes/attributes.adoc[]
 
-All configuration properties are fixed at build time.
+Configuration properties are organized by phase. Build-time properties are fixed during the build and cannot be changed at runtime. Runtime properties can be set at startup.
 
 include::includes/quarkus-json-rpc.adoc[leveloffset=+1, opts=optional]

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -7,11 +7,13 @@ import java.util.function.Supplier;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCBroadcaster;
+import io.quarkiverse.jsonrpc.runtime.config.JsonRPCRuntimeConfig;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCCodec;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
@@ -20,6 +22,12 @@ import io.vertx.ext.web.RoutingContext;
 public class JsonRPCRecorder {
 
     static volatile JsonRPCMetricsHandler metrics;
+
+    private final RuntimeValue<JsonRPCRuntimeConfig> runtimeConfig;
+
+    public JsonRPCRecorder(RuntimeValue<JsonRPCRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public void initMetrics() {
         metrics = JsonRPCMetrics.create();
@@ -50,7 +58,8 @@ public class JsonRPCRecorder {
                 return new JsonRPCRouter(
                         context.getInjectedReference(JsonRPCCodec.class),
                         context.getInjectedReference(JsonRPCSessions.class),
-                        methodsMap);
+                        methodsMap,
+                        runtimeConfig.getValue().methodTimeout().orElse(null));
             }
         };
     }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -2,11 +2,13 @@ package io.quarkiverse.jsonrpc.runtime;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
@@ -72,10 +74,13 @@ public class JsonRPCRouter {
 
     private final JsonRPCSessions sessions;
 
+    private final Duration methodTimeout;
+
     public JsonRPCRouter(JsonRPCCodec codec, JsonRPCSessions sessions,
-            Map<JsonRPCMethodName, JsonRPCMethod> methodsMap) {
+            Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, Duration methodTimeout) {
         this.codec = codec;
         this.sessions = sessions;
+        this.methodTimeout = methodTimeout;
         populateJsonRPCMethods(methodsMap);
     }
 
@@ -542,6 +547,9 @@ public class JsonRPCRouter {
                     return Uni.createFrom()
                             .item(new DispatchResult(errorResponse(jsonRpcRequest.getId(), methodName, unwrap(e))));
                 }
+                if (methodTimeout != null) {
+                    uni = uni.ifNoItem().after(methodTimeout).fail();
+                }
                 return uni
                         .<DispatchResult> map(item -> {
                             if (m != null) {
@@ -590,8 +598,21 @@ public class JsonRPCRouter {
             return new JsonRPCResponse.Error(JsonRPCKeys.FORBIDDEN,
                     "Method [" + methodName + "] failed: " + exception.getMessage());
         }
+        if (isTimeoutException(exception)) {
+            return new JsonRPCResponse.Error(JsonRPCKeys.TIMEOUT,
+                    "Method [" + methodName + "] timed out");
+        }
         return new JsonRPCResponse.Error(JsonRPCKeys.INTERNAL_ERROR,
                 "Method [" + methodName + "] failed: " + exception.getMessage());
+    }
+
+    private static final Set<String> TIMEOUT_EXCEPTION_NAMES = Set.of(
+            "java.util.concurrent.TimeoutException",
+            "io.smallrye.mutiny.TimeoutException",
+            "org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException");
+
+    private static boolean isTimeoutException(Throwable exception) {
+        return TIMEOUT_EXCEPTION_NAMES.contains(exception.getClass().getName());
     }
 
     private List<JsonRPCExceptionMapper> getExceptionMappers() {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/config/JsonRPCRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/config/JsonRPCRuntimeConfig.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.jsonrpc.runtime.config;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "quarkus.json-rpc")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface JsonRPCRuntimeConfig {
+
+    /**
+     * Global timeout for JSON-RPC method execution.
+     * If a method does not complete within this duration, a timeout error is returned to the client.
+     * Applies to all non-streaming methods (not Multi or Flow.Publisher).
+     * Per-method timeouts can be configured using MicroProfile Fault Tolerance's {@code @Timeout} annotation
+     * when {@code quarkus-smallrye-fault-tolerance} is on the classpath.
+     */
+    Optional<Duration> methodTimeout();
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCKeys.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCKeys.java
@@ -26,4 +26,5 @@ public interface JsonRPCKeys {
     // Server-defined errors (JSON-RPC 2.0 reserved range: -32000 to -32099)
     public static final int UNAUTHORIZED = -32000; // Unauthorized. Authentication is required but was not provided or is invalid.
     public static final int FORBIDDEN = -32001; // Forbidden. Authenticated but not authorized for the requested method.
+    public static final int TIMEOUT = -32002; // Timeout. Method execution did not complete within the configured time limit.
 }


### PR DESCRIPTION
If a blocking method call hangs, it ties up a worker thread indefinitely and the client never learns the call failed. This adds two complementary timeout mechanisms:

**Global timeout** — a new runtime config property `quarkus.json-rpc.method-timeout` (e.g. `30s`) that applies to all non-streaming methods as a safety net. Implemented via Mutiny's `ifNoItem().after(duration).fail()` on the Uni returned by the router's `invoke()` method.

**Per-method timeout via MicroProfile Fault Tolerance** — since `@JsonRPCApi` classes are CDI beans and the router invokes methods through CDI proxies, SmallRye Fault Tolerance's `@Timeout` interceptor works automatically. Users just add `quarkus-smallrye-fault-tolerance` to their project and annotate methods. Other FT annotations (`@Retry`, `@Fallback`, etc.) also work.

Both mechanisms produce a JSON-RPC error with code `-32002` (Timeout), sitting in the server-defined range alongside Unauthorized (`-32000`) and Forbidden (`-32001`). Timeout exceptions from Mutiny, the JDK, and MP Fault Tolerance are all recognized by class name, avoiding compile-time dependencies.

Closes #135