### PR TITLE
Add health check integration

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
@@ -64,6 +68,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -63,6 +63,7 @@ import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
@@ -287,6 +288,12 @@ public class JsonRPCProcessor {
         } else {
             recorder.clearMetrics();
         }
+    }
+
+    @BuildStep
+    HealthBuildItem addHealthCheck(JsonRPCConfig config) {
+        return new HealthBuildItem("io.quarkiverse.jsonrpc.runtime.JsonRPCHealthCheck",
+                config.health().enabled());
     }
 
     @BuildStep

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
@@ -23,4 +23,10 @@ public interface JsonRPCConfig {
      */
     @WithName("js-client")
     JsonRPCClientConfig jsClient();
+
+    /**
+     * Configuration properties for the health check
+     */
+    @WithName("health")
+    JsonRPCHealthConfig health();
 }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCHealthConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCHealthConfig.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.jsonrpc.deployment.config;
+
+import io.smallrye.config.WithDefault;
+
+public interface JsonRPCHealthConfig {
+
+    /**
+     * Whether the JSON-RPC health check is enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/HealthCheckDisabledJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/HealthCheckDisabledJsonRpcTest.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.health.SmallRyeHealthReporter;
+
+public class HealthCheckDisabledJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class))
+            .overrideConfigKey("quarkus.json-rpc.health.enabled", "false");
+
+    @Inject
+    SmallRyeHealthReporter reporter;
+
+    @Test
+    public void testHealthCheckAbsent() {
+        String payload = reporter.getHealth().getPayload().toString();
+        assertFalse(payload.contains("JSON-RPC WebSocket"),
+                "Health check should not be present when disabled");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/HealthCheckJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/HealthCheckJsonRpcTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.health.SmallRyeHealth;
+import io.smallrye.health.SmallRyeHealthReporter;
+
+public class HealthCheckJsonRpcTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(HelloResource.class));
+
+    @Inject
+    SmallRyeHealthReporter reporter;
+
+    @Test
+    public void testHealthCheckPresent() {
+        SmallRyeHealth health = reporter.getHealth();
+        assertEquals(HealthCheckResponse.Status.UP, health.getStatus());
+
+        String payload = health.getPayload().toString();
+        assertTrue(payload.contains("JSON-RPC WebSocket"), "Health check should be named 'JSON-RPC WebSocket'");
+        assertTrue(payload.contains("activeConnections"), "Health check should report activeConnections");
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -12,6 +12,7 @@
 ** xref:guides-connection-lifecycle.adoc[Connection Lifecycle Events]
 ** xref:guides-timeouts.adoc[Timeouts]
 ** xref:guides-metrics.adoc[Metrics]
+** xref:guides-health.adoc[Health Check]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 
 .Reference

--- a/docs/modules/ROOT/pages/guides-health.adoc
+++ b/docs/modules/ROOT/pages/guides-health.adoc
@@ -1,0 +1,50 @@
+= Health Check
+
+include::./includes/attributes.adoc[]
+
+When the `quarkus-smallrye-health` extension is present, JSON-RPC automatically contributes a readiness health check that reports the WebSocket endpoint status and active connection count. No code changes are needed.
+
+== Setup
+
+Add the SmallRye Health extension:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
+
+That's it — the health check is registered automatically.
+
+== Health Check Output
+
+The readiness endpoint (`/q/health/ready`) will include a `JSON-RPC WebSocket` check:
+
+[source,json]
+----
+{
+  "status": "UP",
+  "checks": [
+    {
+      "name": "JSON-RPC WebSocket",
+      "status": "UP",
+      "data": {
+        "activeConnections": 3
+      }
+    }
+  ]
+}
+----
+
+The check always reports `UP` when the WebSocket endpoint is running, and includes the current number of open WebSocket connections as additional data.
+
+== Disabling the Health Check
+
+The health check is enabled by default. To disable it, set:
+
+[source,properties]
+----
+quarkus.json-rpc.health.enabled=false
+----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -76,6 +76,9 @@ Complex types are serialized and deserialized automatically via Jackson, includi
 Security::
 Secure your endpoints with standard Jakarta security annotations (`@RolesAllowed`, `@Authenticated`, etc.) or Quarkus HTTP auth policies — opt-in, no changes needed for unsecured use cases.
 
+Health check::
+When SmallRye Health is on the classpath, a readiness check is registered automatically — reporting endpoint status and active connection count.
+
 Timeouts::
 Protect against hanging methods with a global timeout or per-method `@Timeout` via MicroProfile Fault Tolerance.
 
@@ -120,6 +123,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 
 | xref:guides-metrics.adoc[Metrics]
 | Automatic request timing and connection tracking with Micrometer.
+
+| xref:guides-health.adoc[Health Check]
+| Automatic readiness health check with active connection count.
 
 | xref:guides-javascript-client.adoc[JavaScript Client]
 | Generate a typed JavaScript proxy for calling your endpoints from the browser.

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>quarkus-micrometer</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHealthCheck.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHealthCheck.java
@@ -18,7 +18,7 @@ public class JsonRPCHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("JSON-RPC WebSocket").up();
-        builder.withData("activeConnections", sessions.getAllSockets().size());
+        builder.withData("activeConnections", sessions.getActiveConnectionCount());
         return builder.build();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHealthCheck.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCHealthCheck.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+@Readiness
+@ApplicationScoped
+public class JsonRPCHealthCheck implements HealthCheck {
+
+    @Inject
+    JsonRPCSessions sessions;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.named("JSON-RPC WebSocket").up();
+        builder.withData("activeConnections", sessions.getAllSockets().size());
+        return builder.build();
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSessions.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSessions.java
@@ -65,6 +65,13 @@ public class JsonRPCSessions {
     }
 
     /**
+     * @return the number of currently active connections
+     */
+    public int getActiveConnectionCount() {
+        return idToSocket.size();
+    }
+
+    /**
      * @return the set of all connected session IDs
      */
     public Set<String> getSessionIds() {


### PR DESCRIPTION
When `quarkus-smallrye-health` is on the classpath, the extension now automatically contributes a readiness health check that reports the JSON-RPC WebSocket endpoint status and active connection count.

Uses the lightweight `quarkus-smallrye-health-spi` `HealthBuildItem` to register the check at build time — no full SmallRye Health compile dependency needed. The runtime module declares `quarkus-smallrye-health` as optional, so the health check class is only activated when the user brings SmallRye Health into their project.

Configurable via `quarkus.json-rpc.health.enabled` (default: `true`).

Closes #136