### PR TITLE
Generate OpenRPC service discovery document

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -316,7 +316,7 @@ public class JsonRPCProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.STATIC_INIT)
     void registerOpenRPCEndpoint(
             JsonRPCConfig jsonRPCConfig,
             JsonRPCRecorder recorder,
@@ -330,7 +330,7 @@ public class JsonRPCProcessor {
         }
 
         OpenRPCDocumentGenerator generator = new OpenRPCDocumentGenerator(
-                combinedIndexBuildItem.getIndex());
+                combinedIndexBuildItem.getIndex(), jsonRPCConfig.openrpc().schemaSimpleNames());
         String openrpcDocument = generator.generate(jsonRPCMethodsBuildItem.getMethodsMap());
 
         routeProducer.produce(

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -317,6 +317,32 @@ public class JsonRPCProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
+    void registerOpenRPCEndpoint(
+            JsonRPCConfig jsonRPCConfig,
+            JsonRPCRecorder recorder,
+            JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
+            CombinedIndexBuildItem combinedIndexBuildItem,
+            BuildProducer<RouteBuildItem> routeProducer,
+            HttpRootPathBuildItem httpRootPathBuildItem) {
+
+        if (!jsonRPCConfig.openrpc().enabled()) {
+            return;
+        }
+
+        OpenRPCDocumentGenerator generator = new OpenRPCDocumentGenerator(
+                combinedIndexBuildItem.getIndex());
+        String openrpcDocument = generator.generate(jsonRPCMethodsBuildItem.getMethodsMap());
+
+        routeProducer.produce(
+                httpRootPathBuildItem.routeBuilder()
+                        .route(jsonRPCConfig.openrpc().path())
+                        .routeConfigKey("quarkus.json-rpc.openrpc.path")
+                        .handler(recorder.openRpcHandler(openrpcDocument))
+                        .build());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
     void registerSubProtocolFilter(
             JsonRPCConfig jsonRPCConfig,
             JsonRPCRecorder recorder,

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -597,6 +597,14 @@ public class JsonRPCProcessor {
                 .icon("font-awesome-solid:plug")
                 .componentLink("qwc-json-rpc-sessions.js"));
 
+        // OpenRPC schema viewer
+        if (jsonRPCConfig.openrpc().enabled()) {
+            card.addPage(Page.externalPageBuilder("OpenRPC")
+                    .url(jsonRPCConfig.openrpc().path())
+                    .isJsonContent()
+                    .icon("font-awesome-solid:file-code"));
+        }
+
         return card;
     }
 

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -330,7 +330,8 @@ public class JsonRPCProcessor {
         }
 
         OpenRPCDocumentGenerator generator = new OpenRPCDocumentGenerator(
-                combinedIndexBuildItem.getIndex(), jsonRPCConfig.openrpc().schemaSimpleNames());
+                combinedIndexBuildItem.getIndex(), jsonRPCConfig.openrpc().schemaSimpleNames(),
+                jsonRPCConfig.openrpc().title(), jsonRPCConfig.openrpc().version());
         String openrpcDocument = generator.generate(jsonRPCMethodsBuildItem.getMethodsMap());
 
         routeProducer.produce(

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
@@ -1,0 +1,416 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
+import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
+
+public class OpenRPCDocumentGenerator {
+
+    private static final String OPENRPC_VERSION = "1.3.2";
+
+    private static final Set<DotName> STREAMING_TYPES = Set.of(
+            DotName.createSimple("io.smallrye.mutiny.Multi"),
+            DotName.createSimple("java.util.concurrent.Flow.Publisher"));
+
+    private static final Set<DotName> REACTIVE_WRAPPERS = Set.of(
+            DotName.createSimple("io.smallrye.mutiny.Uni"),
+            DotName.createSimple("io.smallrye.mutiny.Multi"),
+            DotName.createSimple("java.util.concurrent.CompletionStage"),
+            DotName.createSimple("java.util.concurrent.CompletableFuture"),
+            DotName.createSimple("java.util.concurrent.Flow.Publisher"));
+
+    private static final Set<DotName> COLLECTION_TYPES = Set.of(
+            DotName.createSimple("java.util.List"),
+            DotName.createSimple("java.util.Set"),
+            DotName.createSimple("java.util.Collection"),
+            DotName.createSimple("java.lang.Iterable"));
+
+    private static final DotName MAP = DotName.createSimple("java.util.Map");
+    private static final DotName OPTIONAL = DotName.createSimple("java.util.Optional");
+
+    private final IndexView index;
+    private final ObjectMapper mapper;
+    private final Map<String, ObjectNode> componentSchemas = new TreeMap<>();
+    private final Set<DotName> schemasInProgress = new HashSet<>();
+
+    public OpenRPCDocumentGenerator(IndexView index) {
+        this.index = index;
+        this.mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    public String generate(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap) {
+        ObjectNode root = mapper.createObjectNode();
+        root.put("openrpc", OPENRPC_VERSION);
+
+        ObjectNode info = mapper.createObjectNode();
+        info.put("title", "JSON-RPC API");
+        info.put("version", "1.0.0");
+        root.set("info", info);
+
+        ArrayNode methods = mapper.createArrayNode();
+
+        for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> entry : methodsMap.entrySet()) {
+            ObjectNode methodNode = buildMethodObject(entry.getKey(), entry.getValue());
+            if (methodNode != null) {
+                methods.add(methodNode);
+            }
+        }
+        root.set("methods", methods);
+
+        if (!componentSchemas.isEmpty()) {
+            ObjectNode components = mapper.createObjectNode();
+            ObjectNode schemas = mapper.createObjectNode();
+            componentSchemas.forEach(schemas::set);
+            components.set("schemas", schemas);
+            root.set("components", components);
+        }
+
+        try {
+            return mapper.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize OpenRPC document", e);
+        }
+    }
+
+    private ObjectNode buildMethodObject(JsonRPCMethodName methodName, JsonRPCMethod method) {
+        MethodInfo jandexMethod = findJandexMethod(method);
+        if (jandexMethod == null) {
+            return null;
+        }
+
+        ObjectNode methodNode = mapper.createObjectNode();
+        methodNode.put("name", methodName.getName());
+
+        ArrayNode params = buildParams(method, jandexMethod);
+        methodNode.set("params", params);
+
+        Type returnType = jandexMethod.returnType();
+        boolean streaming = isStreamingType(returnType);
+        Type effectiveReturnType = unwrapReactiveType(returnType);
+
+        if (effectiveReturnType.kind() != Type.Kind.VOID) {
+            ObjectNode result = mapper.createObjectNode();
+            result.put("name", "result");
+            result.set("schema", typeToJsonSchema(effectiveReturnType));
+            methodNode.set("result", result);
+        }
+
+        if (streaming) {
+            ArrayNode tags = mapper.createArrayNode();
+            ObjectNode tag = mapper.createObjectNode();
+            tag.put("name", "subscription");
+            tags.add(tag);
+            methodNode.set("tags", tags);
+        }
+
+        return methodNode;
+    }
+
+    private ArrayNode buildParams(JsonRPCMethod method, MethodInfo jandexMethod) {
+        ArrayNode params = mapper.createArrayNode();
+        if (!method.hasParams()) {
+            return params;
+        }
+
+        List<String> paramNames = List.copyOf(method.getParams().keySet());
+        for (int i = 0; i < paramNames.size(); i++) {
+            ObjectNode param = mapper.createObjectNode();
+            param.put("name", paramNames.get(i));
+            param.put("required", true);
+            param.set("schema", typeToJsonSchema(jandexMethod.parameterType(i)));
+            params.add(param);
+        }
+        return params;
+    }
+
+    private ObjectNode typeToJsonSchema(Type type) {
+        switch (type.kind()) {
+            case VOID:
+                return mapper.createObjectNode();
+            case PRIMITIVE:
+                return primitiveSchema(type.asPrimitiveType().primitive().name());
+            case ARRAY:
+                return arraySchema(type.asArrayType().componentType());
+            case CLASS:
+                return classTypeSchema(type.asClassType().name());
+            case PARAMETERIZED_TYPE:
+                return parameterizedTypeSchema(type.asParameterizedType());
+            default:
+                return mapper.createObjectNode();
+        }
+    }
+
+    private ObjectNode primitiveSchema(String primitiveName) {
+        ObjectNode schema = mapper.createObjectNode();
+        switch (primitiveName) {
+            case "BOOLEAN":
+                schema.put("type", "boolean");
+                break;
+            case "BYTE":
+            case "SHORT":
+            case "INT":
+                schema.put("type", "integer");
+                break;
+            case "LONG":
+                schema.put("type", "integer");
+                schema.put("format", "int64");
+                break;
+            case "FLOAT":
+                schema.put("type", "number");
+                schema.put("format", "float");
+                break;
+            case "DOUBLE":
+                schema.put("type", "number");
+                schema.put("format", "double");
+                break;
+            case "CHAR":
+                schema.put("type", "string");
+                break;
+            default:
+                break;
+        }
+        return schema;
+    }
+
+    private ObjectNode arraySchema(Type componentType) {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "array");
+        schema.set("items", typeToJsonSchema(componentType));
+        return schema;
+    }
+
+    private ObjectNode classTypeSchema(DotName name) {
+        String fqn = name.toString();
+
+        // Boxed primitives
+        switch (fqn) {
+            case "java.lang.String":
+            case "java.lang.Character":
+                return schemaWith("string", null);
+            case "java.lang.Boolean":
+                return schemaWith("boolean", null);
+            case "java.lang.Byte":
+            case "java.lang.Short":
+            case "java.lang.Integer":
+                return schemaWith("integer", null);
+            case "java.lang.Long":
+                return schemaWith("integer", "int64");
+            case "java.lang.Float":
+                return schemaWith("number", "float");
+            case "java.lang.Double":
+                return schemaWith("number", "double");
+            case "java.lang.Number":
+                return schemaWith("number", null);
+
+            // Well-known types
+            case "java.util.UUID":
+                return schemaWith("string", "uuid");
+            case "java.time.LocalDateTime":
+            case "java.time.OffsetDateTime":
+            case "java.time.ZonedDateTime":
+            case "java.time.Instant":
+                return schemaWith("string", "date-time");
+            case "java.time.LocalDate":
+                return schemaWith("string", "date");
+            case "java.time.LocalTime":
+            case "java.time.OffsetTime":
+                return schemaWith("string", "time");
+            case "java.time.Duration":
+            case "java.time.Period":
+                return schemaWith("string", null);
+            case "java.math.BigDecimal":
+            case "java.math.BigInteger":
+                return schemaWith("string", null);
+            case "java.lang.Object":
+            case "com.fasterxml.jackson.databind.JsonNode":
+                return mapper.createObjectNode();
+        }
+
+        // Enum check via Jandex
+        ClassInfo classInfo = index.getClassByName(name);
+        if (classInfo != null && classInfo.isEnum()) {
+            return enumSchema(classInfo);
+        }
+
+        // POJO — generate component schema and return $ref
+        return generatePojoRef(name);
+    }
+
+    private ObjectNode parameterizedTypeSchema(ParameterizedType type) {
+        DotName rawName = type.name();
+        List<Type> args = type.arguments();
+
+        // Optional<T> → schema for T
+        if (OPTIONAL.equals(rawName) && !args.isEmpty()) {
+            return typeToJsonSchema(args.get(0));
+        }
+
+        // Reactive wrappers — unwrap
+        if (REACTIVE_WRAPPERS.contains(rawName) && !args.isEmpty()) {
+            return typeToJsonSchema(args.get(0));
+        }
+
+        // Collection types → array
+        if (COLLECTION_TYPES.contains(rawName)) {
+            ObjectNode schema = mapper.createObjectNode();
+            schema.put("type", "array");
+            schema.set("items", args.isEmpty() ? mapper.createObjectNode() : typeToJsonSchema(args.get(0)));
+            return schema;
+        }
+
+        // Map<K, V> → object with additionalProperties
+        if (MAP.equals(rawName)) {
+            ObjectNode schema = mapper.createObjectNode();
+            schema.put("type", "object");
+            schema.set("additionalProperties", args.size() >= 2 ? typeToJsonSchema(args.get(1)) : mapper.createObjectNode());
+            return schema;
+        }
+
+        // Fall back to raw type
+        return classTypeSchema(rawName);
+    }
+
+    private ObjectNode enumSchema(ClassInfo classInfo) {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "string");
+        ArrayNode enumValues = mapper.createArrayNode();
+        for (FieldInfo field : classInfo.fields()) {
+            if (field.type().name().equals(classInfo.name())) {
+                enumValues.add(field.name());
+            }
+        }
+        schema.set("enum", enumValues);
+        return schema;
+    }
+
+    private ObjectNode generatePojoRef(DotName name) {
+        String simpleName = name.local();
+
+        if (!componentSchemas.containsKey(simpleName) && !schemasInProgress.contains(name)) {
+            schemasInProgress.add(name);
+            ObjectNode pojoSchema = buildPojoSchema(name);
+            if (pojoSchema != null) {
+                componentSchemas.put(simpleName, pojoSchema);
+            }
+            schemasInProgress.remove(name);
+        }
+
+        return createRef(simpleName);
+    }
+
+    private ObjectNode buildPojoSchema(DotName name) {
+        ClassInfo classInfo = index.getClassByName(name);
+        if (classInfo == null) {
+            return null;
+        }
+
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode properties = mapper.createObjectNode();
+
+        // Public fields
+        for (FieldInfo field : classInfo.fields()) {
+            if (java.lang.reflect.Modifier.isStatic(field.flags())) {
+                continue;
+            }
+            if (java.lang.reflect.Modifier.isPublic(field.flags())) {
+                properties.set(field.name(), typeToJsonSchema(field.type()));
+            }
+        }
+
+        // Getter methods (getXxx/isXxx for private fields)
+        for (MethodInfo method : classInfo.methods()) {
+            String methodName = method.name();
+            if (method.parametersCount() != 0 || method.returnType().kind() == Type.Kind.VOID) {
+                continue;
+            }
+            String propertyName = null;
+            if (methodName.startsWith("get") && methodName.length() > 3) {
+                propertyName = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+            } else if (methodName.startsWith("is") && methodName.length() > 2) {
+                propertyName = Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+            }
+            if (propertyName != null && !properties.has(propertyName)) {
+                properties.set(propertyName, typeToJsonSchema(method.returnType()));
+            }
+        }
+
+        if (properties.size() > 0) {
+            schema.set("properties", properties);
+        }
+        return schema;
+    }
+
+    private ObjectNode createRef(String typeName) {
+        ObjectNode ref = mapper.createObjectNode();
+        ref.put("$ref", "#/components/schemas/" + typeName);
+        return ref;
+    }
+
+    private ObjectNode schemaWith(String type, String format) {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", type);
+        if (format != null) {
+            schema.put("format", format);
+        }
+        return schema;
+    }
+
+    private Type unwrapReactiveType(Type type) {
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            DotName rawName = type.asParameterizedType().name();
+            if (REACTIVE_WRAPPERS.contains(rawName)) {
+                List<Type> args = type.asParameterizedType().arguments();
+                if (!args.isEmpty()) {
+                    return args.get(0);
+                }
+            }
+        }
+        return type;
+    }
+
+    private boolean isStreamingType(Type type) {
+        DotName name;
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            name = type.asParameterizedType().name();
+        } else if (type.kind() == Type.Kind.CLASS) {
+            name = type.asClassType().name();
+        } else {
+            return false;
+        }
+        return STREAMING_TYPES.contains(name);
+    }
+
+    private MethodInfo findJandexMethod(JsonRPCMethod method) {
+        ClassInfo classInfo = index.getClassByName(method.getClazz().getName());
+        if (classInfo == null) {
+            return null;
+        }
+        int paramCount = method.hasParams() ? method.getParams().size() : 0;
+        for (MethodInfo mi : classInfo.methods()) {
+            if (mi.name().equals(method.getMethodName()) && mi.parametersCount() == paramCount) {
+                return mi;
+            }
+        }
+        return null;
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
@@ -49,11 +49,13 @@ public class OpenRPCDocumentGenerator {
 
     private final IndexView index;
     private final ObjectMapper mapper;
+    private final boolean schemaSimpleNames;
     private final Map<String, ObjectNode> componentSchemas = new TreeMap<>();
     private final Set<DotName> schemasInProgress = new HashSet<>();
 
-    public OpenRPCDocumentGenerator(IndexView index) {
+    public OpenRPCDocumentGenerator(IndexView index, boolean schemaSimpleNames) {
         this.index = index;
+        this.schemaSimpleNames = schemaSimpleNames;
         this.mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
     }
 
@@ -303,19 +305,21 @@ public class OpenRPCDocumentGenerator {
     }
 
     private ObjectNode generatePojoRef(DotName name) {
-        String simpleName = name.local();
+        String schemaKey = schemaSimpleNames ? name.local() : name.toString();
 
-        if (!componentSchemas.containsKey(simpleName) && !schemasInProgress.contains(name)) {
+        if (!componentSchemas.containsKey(schemaKey) && !schemasInProgress.contains(name)) {
             schemasInProgress.add(name);
             ObjectNode pojoSchema = buildPojoSchema(name);
             if (pojoSchema != null) {
-                componentSchemas.put(simpleName, pojoSchema);
+                componentSchemas.put(schemaKey, pojoSchema);
             }
             schemasInProgress.remove(name);
         }
 
-        return createRef(simpleName);
+        return createRef(schemaKey);
     }
+
+    private static final DotName JAVA_LANG_OBJECT = DotName.createSimple("java.lang.Object");
 
     private ObjectNode buildPojoSchema(DotName name) {
         ClassInfo classInfo = index.getClassByName(name);
@@ -327,17 +331,32 @@ public class OpenRPCDocumentGenerator {
         schema.put("type", "object");
         ObjectNode properties = mapper.createObjectNode();
 
-        // Public fields
+        ClassInfo current = classInfo;
+        while (current != null) {
+            collectProperties(current, properties);
+            DotName superName = current.superName();
+            if (superName == null || JAVA_LANG_OBJECT.equals(superName)) {
+                break;
+            }
+            current = index.getClassByName(superName);
+        }
+
+        if (!properties.isEmpty()) {
+            schema.set("properties", properties);
+        }
+        return schema;
+    }
+
+    private void collectProperties(ClassInfo classInfo, ObjectNode properties) {
         for (FieldInfo field : classInfo.fields()) {
             if (java.lang.reflect.Modifier.isStatic(field.flags())) {
                 continue;
             }
-            if (java.lang.reflect.Modifier.isPublic(field.flags())) {
+            if (java.lang.reflect.Modifier.isPublic(field.flags()) && !properties.has(field.name())) {
                 properties.set(field.name(), typeToJsonSchema(field.type()));
             }
         }
 
-        // Getter methods (getXxx/isXxx for private fields)
         for (MethodInfo method : classInfo.methods()) {
             String methodName = method.name();
             if (method.parametersCount() != 0 || method.returnType().kind() == Type.Kind.VOID) {
@@ -353,11 +372,6 @@ public class OpenRPCDocumentGenerator {
                 properties.set(propertyName, typeToJsonSchema(method.returnType()));
             }
         }
-
-        if (properties.size() > 0) {
-            schema.set("properties", properties);
-        }
-        return schema;
     }
 
     private ObjectNode createRef(String typeName) {
@@ -405,9 +419,19 @@ public class OpenRPCDocumentGenerator {
         if (classInfo == null) {
             return null;
         }
-        int paramCount = method.hasParams() ? method.getParams().size() : 0;
+        List<Class> paramTypes = method.hasParams() ? List.copyOf(method.getParams().values()) : List.of();
         for (MethodInfo mi : classInfo.methods()) {
-            if (mi.name().equals(method.getMethodName()) && mi.parametersCount() == paramCount) {
+            if (!mi.name().equals(method.getMethodName()) || mi.parametersCount() != paramTypes.size()) {
+                continue;
+            }
+            boolean match = true;
+            for (int i = 0; i < paramTypes.size(); i++) {
+                if (!mi.parameterType(i).name().toString().equals(paramTypes.get(i).getName())) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
                 return mi;
             }
         }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import java.lang.reflect.Modifier;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -59,12 +60,16 @@ public class OpenRPCDocumentGenerator {
     private final IndexView index;
     private final ObjectMapper mapper;
     private final boolean schemaSimpleNames;
+    private final String title;
+    private final String version;
     private final Map<String, ObjectNode> componentSchemas = new TreeMap<>();
     private final Set<DotName> schemasInProgress = new HashSet<>();
 
-    public OpenRPCDocumentGenerator(IndexView index, boolean schemaSimpleNames) {
+    public OpenRPCDocumentGenerator(IndexView index, boolean schemaSimpleNames, String title, String version) {
         this.index = index;
         this.schemaSimpleNames = schemaSimpleNames;
+        this.title = title;
+        this.version = version;
         this.mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
     }
 
@@ -73,18 +78,20 @@ public class OpenRPCDocumentGenerator {
         root.put("openrpc", OPENRPC_VERSION);
 
         ObjectNode info = mapper.createObjectNode();
-        info.put("title", "JSON-RPC API");
-        info.put("version", "1.0.0");
+        info.put("title", title);
+        info.put("version", version);
         root.set("info", info);
 
         ArrayNode methods = mapper.createArrayNode();
 
-        for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> entry : methodsMap.entrySet()) {
-            ObjectNode methodNode = buildMethodObject(entry.getKey(), entry.getValue());
-            if (methodNode != null) {
-                methods.add(methodNode);
-            }
-        }
+        methodsMap.entrySet().stream()
+                .sorted(Comparator.comparing(e -> e.getKey().getName()))
+                .forEach(entry -> {
+                    ObjectNode methodNode = buildMethodObject(entry.getKey(), entry.getValue());
+                    if (methodNode != null) {
+                        methods.add(methodNode);
+                    }
+                });
         root.set("methods", methods);
 
         if (!componentSchemas.isEmpty()) {
@@ -369,6 +376,7 @@ public class OpenRPCDocumentGenerator {
 
     private void collectProperties(ClassInfo classInfo, ObjectNode properties) {
         Set<String> ignoredByField = new HashSet<>();
+        Set<String> ignoredByGetter = new HashSet<>();
         Map<String, String> fieldRenames = new HashMap<>();
 
         for (FieldInfo field : classInfo.fields()) {
@@ -383,11 +391,6 @@ public class OpenRPCDocumentGenerator {
             if (!resolvedName.equals(field.name())) {
                 fieldRenames.put(field.name(), resolvedName);
             }
-            if (Modifier.isPublic(field.flags())) {
-                if (!properties.has(resolvedName)) {
-                    properties.set(resolvedName, typeToJsonSchema(field.type()));
-                }
-            }
         }
 
         for (MethodInfo method : classInfo.methods()) {
@@ -395,16 +398,15 @@ public class OpenRPCDocumentGenerator {
             if (method.parametersCount() != 0 || method.returnType().kind() == Type.Kind.VOID) {
                 continue;
             }
-            if (method.hasAnnotation(JSON_IGNORE)) {
+            String derivedName = derivePropertyName(methodName);
+            if (derivedName == null) {
                 continue;
             }
-            String derivedName = null;
-            if (methodName.startsWith("get") && methodName.length() > 3) {
-                derivedName = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
-            } else if (methodName.startsWith("is") && methodName.length() > 2) {
-                derivedName = Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+            if (method.hasAnnotation(JSON_IGNORE)) {
+                ignoredByGetter.add(derivedName);
+                continue;
             }
-            if (derivedName != null && !ignoredByField.contains(derivedName)) {
+            if (!ignoredByField.contains(derivedName)) {
                 String propertyName = resolvePropertyName(method.annotation(JSON_PROPERTY), derivedName);
                 if (propertyName.equals(derivedName) && fieldRenames.containsKey(derivedName)) {
                     propertyName = fieldRenames.get(derivedName);
@@ -414,6 +416,32 @@ public class OpenRPCDocumentGenerator {
                 }
             }
         }
+
+        Set<String> allIgnored = new HashSet<>(ignoredByField);
+        allIgnored.addAll(ignoredByGetter);
+
+        for (FieldInfo field : classInfo.fields()) {
+            if (Modifier.isStatic(field.flags()) || !Modifier.isPublic(field.flags())) {
+                continue;
+            }
+            if (allIgnored.contains(field.name())) {
+                continue;
+            }
+            String resolvedName = resolvePropertyName(field.annotation(JSON_PROPERTY), field.name());
+            if (!properties.has(resolvedName)) {
+                properties.set(resolvedName, typeToJsonSchema(field.type()));
+            }
+        }
+    }
+
+    private String derivePropertyName(String methodName) {
+        if (methodName.startsWith("get") && methodName.length() > 3) {
+            return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+        }
+        if (methodName.startsWith("is") && methodName.length() > 2) {
+            return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+        }
+        return null;
     }
 
     private String resolvePropertyName(AnnotationInstance jsonProperty, String defaultName) {
@@ -466,6 +494,7 @@ public class OpenRPCDocumentGenerator {
         return STREAMING_TYPES.contains(name);
     }
 
+    @SuppressWarnings("rawtypes")
     private MethodInfo findJandexMethod(JsonRPCMethod method) {
         ClassInfo classInfo = index.getClassByName(method.getClazz().getName());
         if (classInfo == null) {

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
@@ -46,6 +48,9 @@ public class OpenRPCDocumentGenerator {
 
     private static final DotName MAP = DotName.createSimple("java.util.Map");
     private static final DotName OPTIONAL = DotName.createSimple("java.util.Optional");
+
+    private static final DotName JSON_IGNORE = DotName.createSimple("com.fasterxml.jackson.annotation.JsonIgnore");
+    private static final DotName JSON_PROPERTY = DotName.createSimple("com.fasterxml.jackson.annotation.JsonProperty");
 
     private final IndexView index;
     private final ObjectMapper mapper;
@@ -240,8 +245,9 @@ public class OpenRPCDocumentGenerator {
             case "java.time.Period":
                 return schemaWith("string", null);
             case "java.math.BigDecimal":
+                return schemaWith("number", null);
             case "java.math.BigInteger":
-                return schemaWith("string", null);
+                return schemaWith("integer", null);
             case "java.lang.Object":
             case "com.fasterxml.jackson.databind.JsonNode":
                 return mapper.createObjectNode();
@@ -348,12 +354,25 @@ public class OpenRPCDocumentGenerator {
     }
 
     private void collectProperties(ClassInfo classInfo, ObjectNode properties) {
+        Set<String> ignoredByField = new HashSet<>();
+        Map<String, String> fieldRenames = new java.util.HashMap<>();
+
         for (FieldInfo field : classInfo.fields()) {
             if (java.lang.reflect.Modifier.isStatic(field.flags())) {
                 continue;
             }
-            if (java.lang.reflect.Modifier.isPublic(field.flags()) && !properties.has(field.name())) {
-                properties.set(field.name(), typeToJsonSchema(field.type()));
+            if (field.hasAnnotation(JSON_IGNORE)) {
+                ignoredByField.add(field.name());
+                continue;
+            }
+            String resolvedName = resolvePropertyName(field.annotation(JSON_PROPERTY), field.name());
+            if (!resolvedName.equals(field.name())) {
+                fieldRenames.put(field.name(), resolvedName);
+            }
+            if (java.lang.reflect.Modifier.isPublic(field.flags())) {
+                if (!properties.has(resolvedName)) {
+                    properties.set(resolvedName, typeToJsonSchema(field.type()));
+                }
             }
         }
 
@@ -362,16 +381,35 @@ public class OpenRPCDocumentGenerator {
             if (method.parametersCount() != 0 || method.returnType().kind() == Type.Kind.VOID) {
                 continue;
             }
-            String propertyName = null;
-            if (methodName.startsWith("get") && methodName.length() > 3) {
-                propertyName = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
-            } else if (methodName.startsWith("is") && methodName.length() > 2) {
-                propertyName = Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+            if (method.hasAnnotation(JSON_IGNORE)) {
+                continue;
             }
-            if (propertyName != null && !properties.has(propertyName)) {
-                properties.set(propertyName, typeToJsonSchema(method.returnType()));
+            String derivedName = null;
+            if (methodName.startsWith("get") && methodName.length() > 3) {
+                derivedName = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+            } else if (methodName.startsWith("is") && methodName.length() > 2) {
+                derivedName = Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+            }
+            if (derivedName != null && !ignoredByField.contains(derivedName)) {
+                String propertyName = resolvePropertyName(method.annotation(JSON_PROPERTY), derivedName);
+                if (propertyName.equals(derivedName) && fieldRenames.containsKey(derivedName)) {
+                    propertyName = fieldRenames.get(derivedName);
+                }
+                if (!properties.has(propertyName)) {
+                    properties.set(propertyName, typeToJsonSchema(method.returnType()));
+                }
             }
         }
+    }
+
+    private String resolvePropertyName(AnnotationInstance jsonProperty, String defaultName) {
+        if (jsonProperty != null) {
+            AnnotationValue value = jsonProperty.value();
+            if (value != null && !value.asString().isEmpty()) {
+                return value.asString();
+            }
+        }
+        return defaultName;
     }
 
     private ObjectNode createRef(String typeName) {

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDocumentGenerator.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.jsonrpc.deployment;
 
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,8 @@ public class OpenRPCDocumentGenerator {
 
     private static final DotName MAP = DotName.createSimple("java.util.Map");
     private static final DotName OPTIONAL = DotName.createSimple("java.util.Optional");
+
+    private static final DotName JAVA_LANG_OBJECT = DotName.createSimple("java.lang.Object");
 
     private static final DotName JSON_IGNORE = DotName.createSimple("com.fasterxml.jackson.annotation.JsonIgnore");
     private static final DotName JSON_PROPERTY = DotName.createSimple("com.fasterxml.jackson.annotation.JsonProperty");
@@ -140,13 +144,24 @@ public class OpenRPCDocumentGenerator {
 
         List<String> paramNames = List.copyOf(method.getParams().keySet());
         for (int i = 0; i < paramNames.size(); i++) {
+            Type paramType = jandexMethod.parameterType(i);
             ObjectNode param = mapper.createObjectNode();
             param.put("name", paramNames.get(i));
-            param.put("required", true);
-            param.set("schema", typeToJsonSchema(jandexMethod.parameterType(i)));
+            param.put("required", !isOptionalType(paramType));
+            param.set("schema", typeToJsonSchema(paramType));
             params.add(param);
         }
         return params;
+    }
+
+    private boolean isOptionalType(Type type) {
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            return OPTIONAL.equals(type.asParameterizedType().name());
+        }
+        if (type.kind() == Type.Kind.CLASS) {
+            return OPTIONAL.equals(type.asClassType().name());
+        }
+        return false;
     }
 
     private ObjectNode typeToJsonSchema(Type type) {
@@ -316,16 +331,15 @@ public class OpenRPCDocumentGenerator {
         if (!componentSchemas.containsKey(schemaKey) && !schemasInProgress.contains(name)) {
             schemasInProgress.add(name);
             ObjectNode pojoSchema = buildPojoSchema(name);
-            if (pojoSchema != null) {
-                componentSchemas.put(schemaKey, pojoSchema);
-            }
             schemasInProgress.remove(name);
+            if (pojoSchema == null) {
+                return mapper.createObjectNode();
+            }
+            componentSchemas.put(schemaKey, pojoSchema);
         }
 
         return createRef(schemaKey);
     }
-
-    private static final DotName JAVA_LANG_OBJECT = DotName.createSimple("java.lang.Object");
 
     private ObjectNode buildPojoSchema(DotName name) {
         ClassInfo classInfo = index.getClassByName(name);
@@ -355,10 +369,10 @@ public class OpenRPCDocumentGenerator {
 
     private void collectProperties(ClassInfo classInfo, ObjectNode properties) {
         Set<String> ignoredByField = new HashSet<>();
-        Map<String, String> fieldRenames = new java.util.HashMap<>();
+        Map<String, String> fieldRenames = new HashMap<>();
 
         for (FieldInfo field : classInfo.fields()) {
-            if (java.lang.reflect.Modifier.isStatic(field.flags())) {
+            if (Modifier.isStatic(field.flags())) {
                 continue;
             }
             if (field.hasAnnotation(JSON_IGNORE)) {
@@ -369,7 +383,7 @@ public class OpenRPCDocumentGenerator {
             if (!resolvedName.equals(field.name())) {
                 fieldRenames.put(field.name(), resolvedName);
             }
-            if (java.lang.reflect.Modifier.isPublic(field.flags())) {
+            if (Modifier.isPublic(field.flags())) {
                 if (!properties.has(resolvedName)) {
                     properties.set(resolvedName, typeToJsonSchema(field.type()));
                 }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCConfig.java
@@ -29,4 +29,10 @@ public interface JsonRPCConfig {
      */
     @WithName("health")
     JsonRPCHealthConfig health();
+
+    /**
+     * Configuration properties for the OpenRPC service discovery document
+     */
+    @WithName("openrpc")
+    JsonRPCOpenRPCConfig openrpc();
 }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCOpenRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCOpenRPCConfig.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.jsonrpc.deployment.config;
+
+import io.smallrye.config.WithDefault;
+
+public interface JsonRPCOpenRPCConfig {
+
+    /**
+     * Whether the OpenRPC service discovery document is enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * HTTP path for the OpenRPC service discovery document.
+     */
+    @WithDefault("/json-rpc/openrpc.json")
+    String path();
+}

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCOpenRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCOpenRPCConfig.java
@@ -15,4 +15,12 @@ public interface JsonRPCOpenRPCConfig {
      */
     @WithDefault("/json-rpc/openrpc.json")
     String path();
+
+    /**
+     * Whether to use simple class names (e.g. {@code Pojo}) instead of fully-qualified names
+     * (e.g. {@code com.example.Pojo}) as schema keys in the {@code components/schemas} section.
+     * Simple names are shorter but may collide when different packages contain classes with the same name.
+     */
+    @WithDefault("false")
+    boolean schemaSimpleNames();
 }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCOpenRPCConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/config/JsonRPCOpenRPCConfig.java
@@ -17,6 +17,18 @@ public interface JsonRPCOpenRPCConfig {
     String path();
 
     /**
+     * Title of the API in the OpenRPC {@code info} object.
+     */
+    @WithDefault("JSON-RPC API")
+    String title();
+
+    /**
+     * Version of the API in the OpenRPC {@code info} object.
+     */
+    @WithDefault("1.0.0")
+    String version();
+
+    /**
      * Whether to use simple class names (e.g. {@code Pojo}) instead of fully-qualified names
      * (e.g. {@code com.example.Pojo}) as schema keys in the {@code components/schemas} section.
      * Simple names are shorter but may collide when different packages contain classes with the same name.

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/AnnotatedPojo.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/AnnotatedPojo.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.jsonrpc.app;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AnnotatedPojo {
+
+    @JsonProperty("display_name")
+    private String name;
+
+    private String description;
+
+    @JsonIgnore
+    private String secret;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/BasePojo.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/BasePojo.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.jsonrpc.app;
+
+public class BasePojo {
+    private String baseField;
+
+    public String getBaseField() {
+        return baseField;
+    }
+
+    public void setBaseField(String baseField) {
+        this.baseField = baseField;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ChildPojo.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/ChildPojo.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.jsonrpc.app;
+
+public class ChildPojo extends BasePojo {
+    private String childField;
+
+    public String getChildField() {
+        return childField;
+    }
+
+    public void setChildField(String childField) {
+        this.childField = childField;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/CollectionResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/CollectionResource.java
@@ -86,6 +86,10 @@ public class CollectionResource {
         return items.length;
     }
 
+    public String withDefault(String name, Optional<String> title) {
+        return title.map(t -> t + " " + name).orElse(name);
+    }
+
     private Pojo createPojo(String name) {
         Pojo pojo = new Pojo();
         pojo.setName(name);

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/PojoResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/PojoResource.java
@@ -63,6 +63,13 @@ public class PojoResource {
                 .onItem().transform(n -> pojo);
     }
 
+    public ChildPojo childPojo() {
+        ChildPojo child = new ChildPojo();
+        child.setBaseField("inherited");
+        child.setChildField("own");
+        return child;
+    }
+
     private Pojo createPojo() {
         return createPojo(null, null, 0L);
     }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/PojoResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/PojoResource.java
@@ -63,6 +63,14 @@ public class PojoResource {
                 .onItem().transform(n -> pojo);
     }
 
+    public AnnotatedPojo annotatedPojo() {
+        AnnotatedPojo pojo = new AnnotatedPojo();
+        pojo.setName("test");
+        pojo.setDescription("a description");
+        pojo.setSecret("hidden");
+        return pojo;
+    }
+
     public ChildPojo childPojo() {
         ChildPojo child = new ChildPojo();
         child.setBaseField("inherited");

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.BasePojo;
+import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.HelloResource;
 import io.quarkiverse.jsonrpc.app.Pojo;
 import io.quarkiverse.jsonrpc.app.Pojo2;
@@ -16,7 +18,8 @@ public class JsClientGenerationTest extends JsClientTestBase {
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
-                root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class, VoidResource.class);
+                root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class,
+                        BasePojo.class, ChildPojo.class, VoidResource.class);
             })
             .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true");
 

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.AnnotatedPojo;
 import io.quarkiverse.jsonrpc.app.BasePojo;
 import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.HelloResource;
@@ -19,7 +20,7 @@ public class JsClientGenerationTest extends JsClientTestBase {
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
                 root.addClasses(HelloResource.class, PojoResource.class, Pojo.class, Pojo2.class,
-                        BasePojo.class, ChildPojo.class, VoidResource.class);
+                        BasePojo.class, ChildPojo.class, AnnotatedPojo.class, VoidResource.class);
             })
             .overrideConfigKey("quarkus.json-rpc.js-client.enabled", "true");
 

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDisabledJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCDisabledJsonRpcTest.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenRPCDisabledJsonRpcTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.openrpc.enabled", "false");
+
+    @Test
+    public void testOpenRPCNotServedWhenDisabled() throws Exception {
+        int status = httpStatus("/json-rpc/openrpc.json");
+        assertNotEquals(200, status, "OpenRPC document should not be served when disabled");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
@@ -3,11 +3,13 @@ package io.quarkiverse.jsonrpc.deployment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.AnnotatedPojo;
 import io.quarkiverse.jsonrpc.app.BasePojo;
 import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.CollectionResource;
@@ -27,7 +29,7 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
             .withApplicationRoot(root -> {
                 root.addClasses(HelloResource.class, PojoResource.class,
                         Pojo.class, Pojo2.class, BasePojo.class, ChildPojo.class,
-                        VoidResource.class, CollectionResource.class);
+                        AnnotatedPojo.class, VoidResource.class, CollectionResource.class);
             });
 
     @Test
@@ -212,7 +214,41 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
         JsonObject doc = new JsonObject(body);
 
         JsonObject method = findMethod(doc, "HelloResource#ignoredMethod");
-        assertFalse(method != null, "@JsonRPCIgnore methods should not appear in OpenRPC");
+        assertNull(method, "@JsonRPCIgnore methods should not appear in OpenRPC");
+    }
+
+    @Test
+    public void testJsonPropertyRenamesSchemaField() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
+        JsonObject annotatedSchema = schemas.getJsonObject("io.quarkiverse.jsonrpc.app.AnnotatedPojo");
+        assertNotNull(annotatedSchema, "Should contain AnnotatedPojo schema");
+
+        JsonObject props = annotatedSchema.getJsonObject("properties");
+        assertNotNull(props);
+        assertTrue(props.containsKey("display_name"),
+                "@JsonProperty(\"display_name\") should rename 'name' to 'display_name'");
+        assertFalse(props.containsKey("name"),
+                "Original field name 'name' should not appear when @JsonProperty renames it");
+    }
+
+    @Test
+    public void testJsonIgnoreExcludesSchemaField() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
+        JsonObject annotatedSchema = schemas.getJsonObject("io.quarkiverse.jsonrpc.app.AnnotatedPojo");
+        assertNotNull(annotatedSchema, "Should contain AnnotatedPojo schema");
+
+        JsonObject props = annotatedSchema.getJsonObject("properties");
+        assertNotNull(props);
+        assertFalse(props.containsKey("secret"),
+                "@JsonIgnore field should not appear in schema");
+        assertTrue(props.containsKey("description"),
+                "Non-ignored field should still appear in schema");
     }
 
     private JsonObject findMethod(JsonObject doc, String methodName) {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.BasePojo;
+import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.CollectionResource;
 import io.quarkiverse.jsonrpc.app.HelloResource;
 import io.quarkiverse.jsonrpc.app.Pojo;
@@ -24,7 +26,8 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
                 root.addClasses(HelloResource.class, PojoResource.class,
-                        Pojo.class, Pojo2.class, VoidResource.class, CollectionResource.class);
+                        Pojo.class, Pojo2.class, BasePojo.class, ChildPojo.class,
+                        VoidResource.class, CollectionResource.class);
             });
 
     @Test
@@ -123,7 +126,7 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
         JsonObject result = method.getJsonObject("result");
         assertNotNull(result);
         String ref = result.getJsonObject("schema").getString("$ref");
-        assertEquals("#/components/schemas/Pojo", ref);
+        assertEquals("#/components/schemas/io.quarkiverse.jsonrpc.app.Pojo", ref);
     }
 
     @Test
@@ -134,7 +137,7 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
         JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
         assertNotNull(schemas);
 
-        JsonObject pojoSchema = schemas.getJsonObject("Pojo");
+        JsonObject pojoSchema = schemas.getJsonObject("io.quarkiverse.jsonrpc.app.Pojo");
         assertNotNull(pojoSchema, "Should contain Pojo schema");
         assertEquals("object", pojoSchema.getString("type"));
 
@@ -145,7 +148,7 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
         assertTrue(props.containsKey("pojo2"));
 
         // Nested Pojo2 should also be in schemas
-        JsonObject pojo2Schema = schemas.getJsonObject("Pojo2");
+        JsonObject pojo2Schema = schemas.getJsonObject("io.quarkiverse.jsonrpc.app.Pojo2");
         assertNotNull(pojo2Schema, "Should contain Pojo2 schema");
     }
 
@@ -173,6 +176,34 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
         JsonObject schema = method.getJsonObject("result").getJsonObject("schema");
         assertEquals("object", schema.getString("type"));
         assertEquals("string", schema.getJsonObject("additionalProperties").getString("type"));
+    }
+
+    @Test
+    public void testInheritedPropertiesIncluded() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
+        JsonObject childSchema = schemas.getJsonObject("io.quarkiverse.jsonrpc.app.ChildPojo");
+        assertNotNull(childSchema, "Should contain ChildPojo schema");
+
+        JsonObject props = childSchema.getJsonObject("properties");
+        assertNotNull(props);
+        assertTrue(props.containsKey("childField"), "Should contain own property");
+        assertTrue(props.containsKey("baseField"), "Should contain inherited property from BasePojo");
+    }
+
+    @Test
+    public void testSchemaUsesFullyQualifiedNamesByDefault() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
+        assertNotNull(schemas);
+        assertTrue(schemas.containsKey("io.quarkiverse.jsonrpc.app.Pojo"),
+                "Schema keys should use fully-qualified names by default");
+        assertFalse(schemas.containsKey("Pojo"),
+                "Schema keys should not use simple names by default");
     }
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
@@ -235,6 +235,28 @@ public class OpenRPCJsonRpcTest extends JsClientTestBase {
     }
 
     @Test
+    public void testOptionalParamIsNotRequired() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "CollectionResource#withDefault(name|title)");
+        assertNotNull(method, "Should find CollectionResource#withDefault(name|title)");
+
+        JsonArray params = method.getJsonArray("params");
+        assertEquals(2, params.size());
+
+        JsonObject nameParam = params.getJsonObject(0);
+        assertEquals("name", nameParam.getString("name"));
+        assertTrue(nameParam.getBoolean("required"), "String param should be required");
+
+        JsonObject titleParam = params.getJsonObject(1);
+        assertEquals("title", titleParam.getString("name"));
+        assertFalse(titleParam.getBoolean("required"), "Optional<String> param should not be required");
+        assertEquals("string", titleParam.getJsonObject("schema").getString("type"),
+                "Optional<String> schema should unwrap to string");
+    }
+
+    @Test
     public void testJsonIgnoreExcludesSchemaField() throws Exception {
         String body = httpGet("/json-rpc/openrpc.json");
         JsonObject doc = new JsonObject(body);

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCJsonRpcTest.java
@@ -1,0 +1,197 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.CollectionResource;
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkiverse.jsonrpc.app.Pojo;
+import io.quarkiverse.jsonrpc.app.Pojo2;
+import io.quarkiverse.jsonrpc.app.PojoResource;
+import io.quarkiverse.jsonrpc.app.VoidResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class OpenRPCJsonRpcTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class, PojoResource.class,
+                        Pojo.class, Pojo2.class, VoidResource.class, CollectionResource.class);
+            });
+
+    @Test
+    public void testOpenRPCDocumentIsServed() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+        assertEquals("1.3.2", doc.getString("openrpc"));
+        assertNotNull(doc.getJsonObject("info"));
+        assertEquals("JSON-RPC API", doc.getJsonObject("info").getString("title"));
+        assertNotNull(doc.getJsonArray("methods"));
+    }
+
+    @Test
+    public void testOpenRPCContainsMethods() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+        JsonArray methods = doc.getJsonArray("methods");
+        assertTrue(methods.size() > 0, "Should contain at least one method");
+
+        boolean found = methods.stream()
+                .map(o -> ((JsonObject) o).getString("name"))
+                .anyMatch(name -> name.startsWith("HelloResource#hello"));
+        assertTrue(found, "Should contain a HelloResource#hello method");
+    }
+
+    @Test
+    public void testMethodWithParamsHasParamSchemas() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "HelloResource#hello(name)");
+        assertNotNull(method, "Should find HelloResource#hello(name)");
+
+        JsonArray params = method.getJsonArray("params");
+        assertEquals(1, params.size());
+        JsonObject param = params.getJsonObject(0);
+        assertEquals("name", param.getString("name"));
+        assertTrue(param.getBoolean("required"));
+        assertEquals("string", param.getJsonObject("schema").getString("type"));
+    }
+
+    @Test
+    public void testMethodWithNoParamsHasEmptyParams() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "HelloResource#hello");
+        assertNotNull(method, "Should find HelloResource#hello (no-arg)");
+
+        JsonArray params = method.getJsonArray("params");
+        assertEquals(0, params.size());
+    }
+
+    @Test
+    public void testUniMethodUnwrapsReturnType() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "HelloResource#helloUni");
+        assertNotNull(method, "Should find HelloResource#helloUni");
+
+        JsonObject result = method.getJsonObject("result");
+        assertNotNull(result);
+        assertEquals("string", result.getJsonObject("schema").getString("type"));
+    }
+
+    @Test
+    public void testMultiMethodHasSubscriptionTag() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "HelloResource#helloMulti");
+        assertNotNull(method, "Should find HelloResource#helloMulti");
+
+        JsonArray tags = method.getJsonArray("tags");
+        assertNotNull(tags, "Streaming method should have tags");
+        boolean hasSubscription = tags.stream()
+                .map(o -> ((JsonObject) o).getString("name"))
+                .anyMatch("subscription"::equals);
+        assertTrue(hasSubscription, "Streaming method should have 'subscription' tag");
+
+        // Result schema should be the unwrapped type (String, not Multi<String>)
+        JsonObject result = method.getJsonObject("result");
+        assertNotNull(result);
+        assertEquals("string", result.getJsonObject("schema").getString("type"));
+    }
+
+    @Test
+    public void testPojoReturnUsesRef() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "PojoResource#pojo");
+        assertNotNull(method, "Should find PojoResource#pojo");
+
+        JsonObject result = method.getJsonObject("result");
+        assertNotNull(result);
+        String ref = result.getJsonObject("schema").getString("$ref");
+        assertEquals("#/components/schemas/Pojo", ref);
+    }
+
+    @Test
+    public void testComponentsSchemasContainsPojo() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
+        assertNotNull(schemas);
+
+        JsonObject pojoSchema = schemas.getJsonObject("Pojo");
+        assertNotNull(pojoSchema, "Should contain Pojo schema");
+        assertEquals("object", pojoSchema.getString("type"));
+
+        JsonObject props = pojoSchema.getJsonObject("properties");
+        assertNotNull(props);
+        assertTrue(props.containsKey("name"));
+        assertTrue(props.containsKey("surname"));
+        assertTrue(props.containsKey("pojo2"));
+
+        // Nested Pojo2 should also be in schemas
+        JsonObject pojo2Schema = schemas.getJsonObject("Pojo2");
+        assertNotNull(pojo2Schema, "Should contain Pojo2 schema");
+    }
+
+    @Test
+    public void testListReturnTypeIsArray() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "CollectionResource#listOfStrings");
+        assertNotNull(method, "Should find CollectionResource#listOfStrings");
+
+        JsonObject schema = method.getJsonObject("result").getJsonObject("schema");
+        assertEquals("array", schema.getString("type"));
+        assertEquals("string", schema.getJsonObject("items").getString("type"));
+    }
+
+    @Test
+    public void testMapReturnTypeHasAdditionalProperties() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "CollectionResource#mapOfStrings");
+        assertNotNull(method, "Should find CollectionResource#mapOfStrings");
+
+        JsonObject schema = method.getJsonObject("result").getJsonObject("schema");
+        assertEquals("object", schema.getString("type"));
+        assertEquals("string", schema.getJsonObject("additionalProperties").getString("type"));
+    }
+
+    @Test
+    public void testIgnoredMethodIsNotIncluded() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject method = findMethod(doc, "HelloResource#ignoredMethod");
+        assertFalse(method != null, "@JsonRPCIgnore methods should not appear in OpenRPC");
+    }
+
+    private JsonObject findMethod(JsonObject doc, String methodName) {
+        JsonArray methods = doc.getJsonArray("methods");
+        for (int i = 0; i < methods.size(); i++) {
+            JsonObject method = methods.getJsonObject(i);
+            if (methodName.equals(method.getString("name"))) {
+                return method;
+            }
+        }
+        return null;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCSimpleNamesJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCSimpleNamesJsonRpcTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.BasePojo;
+import io.quarkiverse.jsonrpc.app.ChildPojo;
+import io.quarkiverse.jsonrpc.app.Pojo;
+import io.quarkiverse.jsonrpc.app.Pojo2;
+import io.quarkiverse.jsonrpc.app.PojoResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class OpenRPCSimpleNamesJsonRpcTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(PojoResource.class, Pojo.class, Pojo2.class,
+                        BasePojo.class, ChildPojo.class);
+            })
+            .overrideConfigKey("quarkus.json-rpc.openrpc.schema-simple-names", "true");
+
+    @Test
+    public void testSchemaUsesSimpleNames() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+
+        JsonObject schemas = doc.getJsonObject("components").getJsonObject("schemas");
+        assertNotNull(schemas);
+        assertTrue(schemas.containsKey("Pojo"), "Schema keys should use simple names when configured");
+        assertTrue(schemas.containsKey("Pojo2"), "Nested schema keys should also use simple names");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCSimpleNamesJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/OpenRPCSimpleNamesJsonRpcTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.AnnotatedPojo;
 import io.quarkiverse.jsonrpc.app.BasePojo;
 import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.Pojo;
@@ -20,7 +21,7 @@ public class OpenRPCSimpleNamesJsonRpcTest extends JsClientTestBase {
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
                 root.addClasses(PojoResource.class, Pojo.class, Pojo2.class,
-                        BasePojo.class, ChildPojo.class);
+                        BasePojo.class, ChildPojo.class, AnnotatedPojo.class);
             })
             .overrideConfigKey("quarkus.json-rpc.openrpc.schema-simple-names", "true");
 

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/PojoJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/PojoJsonRpcTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.BasePojo;
+import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.Pojo;
 import io.quarkiverse.jsonrpc.app.Pojo2;
 import io.quarkiverse.jsonrpc.app.PojoResource;
@@ -17,7 +19,8 @@ public class PojoJsonRpcTest extends JsonRpcParent {
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
-                root.addClasses(PojoResource.class, Pojo.class, Pojo2.class);
+                root.addClasses(PojoResource.class, Pojo.class, Pojo2.class,
+                        BasePojo.class, ChildPojo.class);
             });
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/PojoJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/PojoJsonRpcTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.jsonrpc.app.AnnotatedPojo;
 import io.quarkiverse.jsonrpc.app.BasePojo;
 import io.quarkiverse.jsonrpc.app.ChildPojo;
 import io.quarkiverse.jsonrpc.app.Pojo;
@@ -20,7 +21,7 @@ public class PojoJsonRpcTest extends JsonRpcParent {
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
                 root.addClasses(PojoResource.class, Pojo.class, Pojo2.class,
-                        BasePojo.class, ChildPojo.class);
+                        BasePojo.class, ChildPojo.class, AnnotatedPojo.class);
             });
 
     @Test

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,7 @@
 ** xref:guides-timeouts.adoc[Timeouts]
 ** xref:guides-metrics.adoc[Metrics]
 ** xref:guides-health.adoc[Health Check]
+** xref:guides-openrpc.adoc[OpenRPC Service Discovery]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
 
 .Reference

--- a/docs/modules/ROOT/pages/guides-openrpc.adoc
+++ b/docs/modules/ROOT/pages/guides-openrpc.adoc
@@ -1,0 +1,152 @@
+= OpenRPC Service Discovery
+
+include::./includes/attributes.adoc[]
+
+The extension can generate an https://open-rpc.org/[OpenRPC] service discovery document — the JSON-RPC equivalent of OpenAPI. The document describes all available methods, their parameters, return types, and JSON Schema definitions for complex types. It is generated at build time from the same `@JsonRPCApi` metadata used for method dispatch, so it is always in sync with your code.
+
+== What You Get
+
+A single HTTP endpoint serves a complete https://spec.open-rpc.org/[OpenRPC 1.3.2] document:
+
+[source,shell]
+----
+curl http://localhost:8080/json-rpc/openrpc.json
+----
+
+[source,json]
+----
+{
+  "openrpc": "1.3.2",
+  "info": {
+    "title": "JSON-RPC API",
+    "version": "1.0.0"
+  },
+  "methods": [
+    {
+      "name": "GreetingService#hello",
+      "params": [
+        {
+          "name": "name",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": { "type": "string" }
+      }
+    }
+  ]
+}
+----
+
+No setup is needed — the endpoint is enabled by default.
+
+== Type Mapping
+
+Java types are mapped to https://json-schema.org/[JSON Schema] automatically:
+
+[cols="1,1"]
+|===
+| Java Type | JSON Schema
+
+| `String`, `char`
+| `{"type": "string"}`
+
+| `int`, `Integer`, `short`, `byte`
+| `{"type": "integer"}`
+
+| `long`, `Long`
+| `{"type": "integer", "format": "int64"}`
+
+| `float`, `Float`
+| `{"type": "number", "format": "float"}`
+
+| `double`, `Double`
+| `{"type": "number", "format": "double"}`
+
+| `boolean`, `Boolean`
+| `{"type": "boolean"}`
+
+| `UUID`
+| `{"type": "string", "format": "uuid"}`
+
+| `LocalDateTime`, `Instant`, `OffsetDateTime`, `ZonedDateTime`
+| `{"type": "string", "format": "date-time"}`
+
+| `LocalDate`
+| `{"type": "string", "format": "date"}`
+
+| `LocalTime`, `OffsetTime`
+| `{"type": "string", "format": "time"}`
+
+| `List<T>`, `Set<T>`, `Collection<T>`, arrays
+| `{"type": "array", "items": <T>}`
+
+| `Map<String, T>`
+| `{"type": "object", "additionalProperties": <T>}`
+
+| `Optional<T>`
+| Schema for `T` (unwrapped)
+
+| Enums
+| `{"type": "string", "enum": [...]}`
+
+| POJOs
+| `{"$ref": "#/components/schemas/ClassName"}`
+|===
+
+Complex types (POJOs) are introspected via their fields and getter methods and placed in the `components/schemas` section with `$ref` pointers. Nested and recursive types are handled automatically.
+
+== Reactive Return Types
+
+Reactive wrappers are unwrapped to their inner type:
+
+* `Uni<String>` → `{"type": "string"}`
+* `CompletionStage<Pojo>` → `{"$ref": "#/components/schemas/Pojo"}`
+
+Streaming types (`Multi<T>`, `Flow.Publisher<T>`) are also unwrapped, and the method is tagged with `"subscription"` to indicate it uses the subscription protocol:
+
+[source,json]
+----
+{
+  "name": "TickerService#ticker",
+  "params": [],
+  "result": {
+    "name": "result",
+    "schema": { "type": "string" }
+  },
+  "tags": [
+    { "name": "subscription" }
+  ]
+}
+----
+
+== Configuration
+
+[cols="1,1,2"]
+|===
+| Property | Default | Description
+
+| `quarkus.json-rpc.openrpc.enabled`
+| `true`
+| Whether to generate and serve the OpenRPC document.
+
+| `quarkus.json-rpc.openrpc.path`
+| `/json-rpc/openrpc.json`
+| HTTP path where the document is served.
+|===
+
+To disable the endpoint entirely:
+
+[source,properties]
+----
+quarkus.json-rpc.openrpc.enabled=false
+----
+
+To serve it at a different path:
+
+[source,properties]
+----
+quarkus.json-rpc.openrpc.path=/api/openrpc
+----

--- a/docs/modules/ROOT/pages/guides-openrpc.adoc
+++ b/docs/modules/ROOT/pages/guides-openrpc.adoc
@@ -98,6 +98,8 @@ Java types are mapped to https://json-schema.org/[JSON Schema] automatically:
 
 Complex types (POJOs) are introspected via their fields and getter methods and placed in the `components/schemas` section with `$ref` pointers. Nested, recursive, and inherited types are handled automatically — properties from superclasses are included in the schema.
 
+Jackson annotations `@JsonIgnore` and `@JsonProperty` are respected: ignored fields are excluded from the schema, and renamed fields use the annotated name.
+
 == Reactive Return Types
 
 Reactive wrappers are unwrapped to their inner type:

--- a/docs/modules/ROOT/pages/guides-openrpc.adoc
+++ b/docs/modules/ROOT/pages/guides-openrpc.adoc
@@ -96,7 +96,7 @@ Java types are mapped to https://json-schema.org/[JSON Schema] automatically:
 | `{"$ref": "#/components/schemas/ClassName"}`
 |===
 
-Complex types (POJOs) are introspected via their fields and getter methods and placed in the `components/schemas` section with `$ref` pointers. Nested and recursive types are handled automatically.
+Complex types (POJOs) are introspected via their fields and getter methods and placed in the `components/schemas` section with `$ref` pointers. Nested, recursive, and inherited types are handled automatically — properties from superclasses are included in the schema.
 
 == Reactive Return Types
 
@@ -139,6 +139,10 @@ During development, the OpenRPC document is also available in the Quarkus Dev UI
 | `quarkus.json-rpc.openrpc.path`
 | `/json-rpc/openrpc.json`
 | HTTP path where the document is served.
+
+| `quarkus.json-rpc.openrpc.schema-simple-names`
+| `false`
+| Use simple class names (e.g. `Pojo`) instead of fully-qualified names (e.g. `com.example.Pojo`) as schema keys in `components/schemas`. Simple names are shorter but may collide when different packages contain classes with the same name.
 |===
 
 To disable the endpoint entirely:

--- a/docs/modules/ROOT/pages/guides-openrpc.adoc
+++ b/docs/modules/ROOT/pages/guides-openrpc.adoc
@@ -142,6 +142,14 @@ During development, the OpenRPC document is also available in the Quarkus Dev UI
 | `/json-rpc/openrpc.json`
 | HTTP path where the document is served.
 
+| `quarkus.json-rpc.openrpc.title`
+| `JSON-RPC API`
+| Title of the API in the OpenRPC `info` object.
+
+| `quarkus.json-rpc.openrpc.version`
+| `1.0.0`
+| Version of the API in the OpenRPC `info` object.
+
 | `quarkus.json-rpc.openrpc.schema-simple-names`
 | `false`
 | Use simple class names (e.g. `Pojo`) instead of fully-qualified names (e.g. `com.example.Pojo`) as schema keys in `components/schemas`. Simple names are shorter but may collide when different packages contain classes with the same name.

--- a/docs/modules/ROOT/pages/guides-openrpc.adoc
+++ b/docs/modules/ROOT/pages/guides-openrpc.adoc
@@ -122,6 +122,10 @@ Streaming types (`Multi<T>`, `Flow.Publisher<T>`) are also unwrapped, and the me
 }
 ----
 
+== Dev UI
+
+During development, the OpenRPC document is also available in the Quarkus Dev UI. The JSON-RPC card includes an "OpenRPC" page that displays the full document with syntax highlighting.
+
 == Configuration
 
 [cols="1,1,2"]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -79,6 +79,9 @@ Secure your endpoints with standard Jakarta security annotations (`@RolesAllowed
 Health check::
 When SmallRye Health is on the classpath, a readiness check is registered automatically — reporting endpoint status and active connection count.
 
+OpenRPC service discovery::
+An OpenRPC 1.3.2 document is generated at build time and served at `/json-rpc/openrpc.json`, describing all methods, parameters, and return types with JSON Schema — enabling automatic client generation and documentation.
+
 Timeouts::
 Protect against hanging methods with a global timeout or per-method `@Timeout` via MicroProfile Fault Tolerance.
 
@@ -126,6 +129,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 
 | xref:guides-health.adoc[Health Check]
 | Automatic readiness health check with active connection count.
+
+| xref:guides-openrpc.adoc[OpenRPC Service Discovery]
+| Machine-readable API description with JSON Schema for all methods.
 
 | xref:guides-javascript-client.adoc[JavaScript Client]
 | Generate a typed JavaScript proxy for calling your endpoints from the browser.

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -82,4 +82,8 @@ public class JsonRPCRecorder {
     public Handler<RoutingContext> subProtocolHandler(String wsPath) {
         return new JsonRPCSubProtocolHandler(wsPath);
     }
+
+    public Handler<RoutingContext> openRpcHandler(String openrpcDocument) {
+        return new OpenRPCHandler(openrpcDocument);
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/OpenRPCHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/OpenRPCHandler.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.jsonrpc.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
+
+public class OpenRPCHandler implements Handler<RoutingContext> {
+
+    private final Buffer content;
+
+    public OpenRPCHandler(String openrpcJson) {
+        this.content = Buffer.buffer(openrpcJson);
+    }
+
+    @Override
+    public void handle(RoutingContext event) {
+        event.response()
+                .putHeader("Content-Type", "application/json")
+                .end(content);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/OpenRPCHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/OpenRPCHandler.java
@@ -1,21 +1,21 @@
 package io.quarkiverse.jsonrpc.runtime;
 
 import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
 
 public class OpenRPCHandler implements Handler<RoutingContext> {
 
-    private final Buffer content;
+    private final String content;
 
     public OpenRPCHandler(String openrpcJson) {
-        this.content = Buffer.buffer(openrpcJson);
+        this.content = openrpcJson;
     }
 
     @Override
     public void handle(RoutingContext event) {
         event.response()
                 .putHeader("Content-Type", "application/json")
+                .putHeader("Cache-Control", "public, max-age=86400")
                 .end(content);
     }
 }


### PR DESCRIPTION
The extension already collects full method metadata at build time via Jandex scanning, but there's no way to expose a machine-readable schema of available JSON-RPC methods at runtime. [OpenRPC](https://open-rpc.org/) is the equivalent of OpenAPI for JSON-RPC services, enabling automatic client code generation and documentation.

This generates an OpenRPC 1.3.2 document at build time from the scanned `@JsonRPCApi` method metadata and serves it at a configurable HTTP path (default `/json-rpc/openrpc.json`).

The generator maps Java types to JSON Schema — primitives, boxed types, `java.time`, `UUID`, enums, POJOs (via Jandex field/getter introspection), collections, maps, and arrays. Complex types produce `$ref` entries in `components/schemas` with recursion protection for circular references. Reactive return types are unwrapped (`Uni<T>` → `T`, `Multi<T>` → `T` with a `subscription` tag).

Configuration:
- `quarkus.json-rpc.openrpc.enabled` (default `true`)
- `quarkus.json-rpc.openrpc.path` (default `/json-rpc/openrpc.json`)

Closes #137