### PR TITLE
Support multiple WebSocket endpoint paths via @JsonRPCApi(path)

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCMethodsBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCMethodsBuildItem.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethod;
 import io.quarkiverse.jsonrpc.runtime.model.JsonRPCMethodName;
@@ -8,12 +9,32 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class JsonRPCMethodsBuildItem extends SimpleBuildItem {
     private final Map<JsonRPCMethodName, JsonRPCMethod> methodsMap;
+    private final Set<String> extraPaths;
+    private final Map<String, String> scopeToPath;
 
-    public JsonRPCMethodsBuildItem(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap) {
+    public JsonRPCMethodsBuildItem(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap,
+            Set<String> extraPaths, Map<String, String> scopeToPath) {
         this.methodsMap = methodsMap;
+        this.extraPaths = extraPaths != null ? Set.copyOf(extraPaths) : Set.of();
+        this.scopeToPath = scopeToPath != null ? Map.copyOf(scopeToPath) : Map.of();
     }
 
     public Map<JsonRPCMethodName, JsonRPCMethod> getMethodsMap() {
         return methodsMap;
+    }
+
+    /**
+     * @return additional WebSocket paths declared via {@code @JsonRPCApi(path = "...")}
+     *         (does not include the default global path)
+     */
+    public Set<String> getExtraPaths() {
+        return extraPaths;
+    }
+
+    /**
+     * @return mapping from scope name to custom path, only for scopes with explicit paths
+     */
+    public Map<String, String> getScopeToPath() {
+        return scopeToPath;
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -485,9 +485,8 @@ public class JsonRPCProcessor {
         // Create additional clients for custom paths
         Set<String> extraPaths = new TreeSet<>(scopeToPath.values());
         Map<String, String> pathToClientVar = new HashMap<>();
-        int clientIdx = 0;
         for (String path : extraPaths) {
-            String varName = "_client" + (clientIdx++);
+            String varName = pathToClientVar(path);
             pathToClientVar.put(path, varName);
             js.append("const ").append(varName).append(" = new JsonRPCClient({ path: '")
                     .append(escapeJsString(path)).append("' });\n");
@@ -612,6 +611,25 @@ public class JsonRPCProcessor {
     }
 
     private record MethodEntry(String scope, String methodName, JsonRPCMethod method) {
+    }
+
+    private static String pathToClientVar(String path) {
+        String stripped = path.startsWith("/") ? path.substring(1) : path;
+        String[] segments = stripped.split("[/-]");
+        StringBuilder sb = new StringBuilder("_");
+        for (int i = 0; i < segments.length; i++) {
+            String seg = segments[i];
+            if (seg.isEmpty()) {
+                continue;
+            }
+            if (i == 0) {
+                sb.append(seg);
+            } else {
+                sb.append(Character.toUpperCase(seg.charAt(0)));
+                sb.append(seg.substring(1));
+            }
+        }
+        return sb.toString();
     }
 
     private static String escapeJsString(String value) {

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -116,6 +117,8 @@ public class JsonRPCProcessor {
 
         Map<JsonRPCMethodName, JsonRPCMethod> methodsMap = new HashMap<>();
         Set<String> nativeClasses = new HashSet<>();
+        Set<String> extraPaths = new LinkedHashSet<>();
+        Map<String, String> scopeToPath = new HashMap<>();
 
         // Let's use the Jandex index to find all methods
         for (AnnotationInstance annotationInstance : jsonRPCApiAnnotatoins) {
@@ -125,6 +128,17 @@ public class JsonRPCProcessor {
             String scope = classInfo.simpleName();
             if (annotationValue != null && !annotationValue.asString().equals("_DEFAULT_SCOPE_")) {
                 scope = annotationValue.asString();
+            }
+
+            AnnotationValue pathValue = annotationInstance.value("path");
+            if (pathValue != null && !pathValue.asString().isEmpty()) {
+                String path = pathValue.asString();
+                if (!path.startsWith("/")) {
+                    throw new IllegalArgumentException(
+                            "@JsonRPCApi path on " + classInfo.name() + " must start with '/', got: " + path);
+                }
+                extraPaths.add(path);
+                scopeToPath.put(scope, path);
             }
 
             Class clazz = JandexReflection.loadClass(classInfo);
@@ -211,7 +225,7 @@ public class JsonRPCProcessor {
 
         }
 
-        jsonRPCMethodsProvider.produce(new JsonRPCMethodsBuildItem(methodsMap));
+        jsonRPCMethodsProvider.produce(new JsonRPCMethodsBuildItem(methodsMap, extraPaths, scopeToPath));
 
         // Add known classes to native
         nativeClasses.add(io.quarkiverse.jsonrpc.runtime.model.JsonRPCResponse.class.getName());
@@ -301,17 +315,30 @@ public class JsonRPCProcessor {
     void registerHandlers(
             JsonRPCConfig jsonRPCConfig,
             JsonRPCRecorder recorder,
+            JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
             BuildProducer<RouteBuildItem> routeProducer,
             BeanContainerBuildItem beanContainerBuildItem,
             HttpRootPathBuildItem httpRootPathBuildItem) {
         if (jsonRPCConfig.webSocket().enabled()) {
-            // Websocket for JsonRPC comms
+            // Default WebSocket route for JsonRPC comms
             routeProducer.produce(
                     httpRootPathBuildItem.routeBuilder()
                             .route(jsonRPCConfig.webSocket().path())
                             .routeConfigKey("quarkus.json-rpc.web-socket.path")
                             .handler(recorder.webSocketHandler(beanContainerBuildItem.getValue()))
                             .build());
+
+            // Extra routes from @JsonRPCApi(path = "...")
+            String defaultPath = jsonRPCConfig.webSocket().path();
+            for (String extraPath : jsonRPCMethodsBuildItem.getExtraPaths()) {
+                if (!extraPath.equals(defaultPath)) {
+                    routeProducer.produce(
+                            httpRootPathBuildItem.routeBuilder()
+                                    .route(extraPath)
+                                    .handler(recorder.webSocketHandler(beanContainerBuildItem.getValue()))
+                                    .build());
+                }
+            }
         }
     }
 
@@ -347,11 +374,16 @@ public class JsonRPCProcessor {
     void registerSubProtocolFilter(
             JsonRPCConfig jsonRPCConfig,
             JsonRPCRecorder recorder,
+            JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
             HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<FilterBuildItem> filterProducer) {
         if (jsonRPCConfig.webSocket().enabled()) {
-            String resolvedPath = httpRootPathBuildItem.resolvePath(jsonRPCConfig.webSocket().path());
-            filterProducer.produce(new FilterBuildItem(recorder.subProtocolHandler(resolvedPath), 300));
+            Set<String> resolvedPaths = new LinkedHashSet<>();
+            resolvedPaths.add(httpRootPathBuildItem.resolvePath(jsonRPCConfig.webSocket().path()));
+            for (String extraPath : jsonRPCMethodsBuildItem.getExtraPaths()) {
+                resolvedPaths.add(httpRootPathBuildItem.resolvePath(extraPath));
+            }
+            filterProducer.produce(new FilterBuildItem(recorder.subProtocolHandler(resolvedPaths), 300));
         }
     }
 
@@ -383,17 +415,33 @@ public class JsonRPCProcessor {
 
         // 2. Generate the typed proxy module
         Map<JsonRPCMethodName, JsonRPCMethod> methodsMap = jsonRPCMethodsBuildItem.getMethodsMap();
-        String proxyJs = generateTypedProxy(methodsMap, jsonRPCConfig.webSocket().path());
+        String proxyJs = generateTypedProxy(methodsMap, jsonRPCConfig.webSocket().path(),
+                jsonRPCMethodsBuildItem.getScopeToPath());
         staticResourceProducer.produce(
                 new GeneratedStaticResourceBuildItem(
                         "/_static/quarkus-json-rpc-api/jsonrpc-api.js",
                         proxyJs.getBytes(StandardCharsets.UTF_8)));
     }
 
-    private String generateTypedProxy(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, String wsPath) {
+    private String generateTypedProxy(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, String wsPath,
+            Map<String, String> scopeToPath) {
         StringBuilder js = new StringBuilder();
         js.append("import { JsonRPCClient } from '@quarkiverse/json-rpc';\n\n");
         js.append("export const client = new JsonRPCClient({ path: '").append(escapeJsString(wsPath)).append("' });\n\n");
+
+        // Create additional clients for custom paths
+        Set<String> extraPaths = new java.util.TreeSet<>(scopeToPath.values());
+        Map<String, String> pathToClientVar = new HashMap<>();
+        int clientIdx = 0;
+        for (String path : extraPaths) {
+            String varName = "_client" + (clientIdx++);
+            pathToClientVar.put(path, varName);
+            js.append("const ").append(varName).append(" = new JsonRPCClient({ path: '")
+                    .append(escapeJsString(path)).append("' });\n");
+        }
+        if (!extraPaths.isEmpty()) {
+            js.append("\n");
+        }
 
         // Group methods by scope and method name (sorted for deterministic output).
         // Multiple overloads of the same method name share one JS proxy entry — the server
@@ -429,13 +477,16 @@ public class JsonRPCProcessor {
             String scope = scopeEntry.getKey();
             Map<String, MethodEntry> methods = scopeEntry.getValue();
 
+            String scopePath = scopeToPath.get(scope);
+            String clientVar = (scopePath != null) ? pathToClientVar.get(scopePath) : "client";
+
             js.append("export const ").append(scope).append(" = {\n");
             int i = 0;
             for (MethodEntry me : methods.values()) {
                 String clientMethod = jsClientMethod(me.method);
                 String methodKey = me.scope + "#" + me.methodName;
                 js.append("    ").append(me.methodName)
-                        .append(": (params) => client.").append(clientMethod)
+                        .append(": (params) => ").append(clientVar).append(".").append(clientMethod)
                         .append("('").append(methodKey).append("', params)");
                 if (i < methods.size() - 1) {
                     js.append(",");

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -79,6 +81,7 @@ public class JsonRPCProcessor {
     private static final DotName JSON_RPC_API = DotName.createSimple("io.quarkiverse.jsonrpc.api.JsonRPCApi");
     private static final DotName JSON_RPC_IGNORE = DotName.createSimple("io.quarkiverse.jsonrpc.api.JsonRPCIgnore");
     private static final Pattern JS_IDENTIFIER = Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$]*$");
+    private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^/[a-zA-Z0-9._/-]+$");
     private static final Set<String> JS_RESERVED_WORDS = Set.of(
             "break", "case", "catch", "class", "const", "continue", "debugger", "default",
             "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for",
@@ -136,6 +139,15 @@ public class JsonRPCProcessor {
                 if (!path.startsWith("/")) {
                     throw new IllegalArgumentException(
                             "@JsonRPCApi path on " + classInfo.name() + " must start with '/', got: " + path);
+                }
+                // Normalize: strip trailing slashes
+                while (path.length() > 1 && path.endsWith("/")) {
+                    path = path.substring(0, path.length() - 1);
+                }
+                if (!VALID_PATH_PATTERN.matcher(path).matches()) {
+                    throw new IllegalArgumentException(
+                            "@JsonRPCApi path on " + classInfo.name()
+                                    + " contains invalid characters, got: " + path);
                 }
                 extraPaths.add(path);
                 scopeToPath.put(scope, path);
@@ -251,7 +263,8 @@ public class JsonRPCProcessor {
             JsonRPCConfig jsonRPCConfig,
             JsonRPCRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
-            JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem) {
+            JsonRPCMethodsBuildItem jsonRPCMethodsBuildItem,
+            HttpRootPathBuildItem httpRootPathBuildItem) {
         if (jsonRPCConfig.webSocket().enabled()) {
             beanProducer.produce(SyntheticBeanBuildItem
                     .configure(JsonRPCSessions.class)
@@ -276,7 +289,10 @@ public class JsonRPCProcessor {
                     .unremovable()
                     .addInjectionPoint(ClassType.create(JsonRPCCodec.class))
                     .addInjectionPoint(ClassType.create(JsonRPCSessions.class))
-                    .createWith(recorder.createJsonRpcRouter(jsonRPCMethodsBuildItem.getMethodsMap()))
+                    .createWith(recorder.createJsonRpcRouter(
+                            jsonRPCMethodsBuildItem.getMethodsMap(),
+                            resolvedScopeToPath(jsonRPCMethodsBuildItem, httpRootPathBuildItem),
+                            httpRootPathBuildItem.resolvePath(jsonRPCConfig.webSocket().path())))
                     .scope(ApplicationScoped.class)
                     .done());
 
@@ -467,7 +483,7 @@ public class JsonRPCProcessor {
         js.append("export const client = new JsonRPCClient({ path: '").append(escapeJsString(wsPath)).append("' });\n\n");
 
         // Create additional clients for custom paths
-        Set<String> extraPaths = new java.util.TreeSet<>(scopeToPath.values());
+        Set<String> extraPaths = new TreeSet<>(scopeToPath.values());
         Map<String, String> pathToClientVar = new HashMap<>();
         int clientIdx = 0;
         for (String path : extraPaths) {
@@ -484,7 +500,7 @@ public class JsonRPCProcessor {
         // Multiple overloads of the same method name share one JS proxy entry — the server
         // resolves the correct overload based on parameters. We validate that all overloads
         // agree on their JS client method category (call / subscribe / notify).
-        Map<String, Map<String, MethodEntry>> byScope = new java.util.TreeMap<>();
+        Map<String, Map<String, MethodEntry>> byScope = new TreeMap<>();
         for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> entry : methodsMap.entrySet()) {
             String key = entry.getKey().getName();
             int hashIdx = key.indexOf('#');
@@ -492,7 +508,7 @@ public class JsonRPCProcessor {
             validateJsIdentifier(scope, "@JsonRPCApi scope");
             String methodName = entry.getValue().getMethodName();
             validateJsIdentifier(methodName, "Method name '" + scope + "#" + methodName + "'");
-            Map<String, MethodEntry> scopeMethods = byScope.computeIfAbsent(scope, k -> new java.util.TreeMap<>());
+            Map<String, MethodEntry> scopeMethods = byScope.computeIfAbsent(scope, k -> new TreeMap<>());
             MethodEntry existing = scopeMethods.get(methodName);
             if (existing != null) {
                 String existingCategory = jsClientMethod(existing.method);
@@ -860,6 +876,15 @@ public class JsonRPCProcessor {
                 break;
         }
         return types;
+    }
+
+    private static Map<String, String> resolvedScopeToPath(JsonRPCMethodsBuildItem methods,
+            HttpRootPathBuildItem httpRootPath) {
+        Map<String, String> resolved = new HashMap<>();
+        for (Map.Entry<String, String> entry : methods.getScopeToPath().entrySet()) {
+            resolved.put(entry.getKey(), httpRootPath.resolvePath(entry.getValue()));
+        }
+        return resolved;
     }
 
     private Class toClass(Type type) {

--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -356,17 +356,54 @@ public class JsonRPCProcessor {
             return;
         }
 
-        OpenRPCDocumentGenerator generator = new OpenRPCDocumentGenerator(
+        Map<JsonRPCMethodName, JsonRPCMethod> allMethods = jsonRPCMethodsBuildItem.getMethodsMap();
+        Map<String, String> scopeToPath = jsonRPCMethodsBuildItem.getScopeToPath();
+
+        // Partition methods: default-path methods vs custom-path methods
+        Map<JsonRPCMethodName, JsonRPCMethod> defaultMethods = new HashMap<>();
+        Map<String, Map<JsonRPCMethodName, JsonRPCMethod>> perPathMethods = new HashMap<>();
+
+        for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> entry : allMethods.entrySet()) {
+            String key = entry.getKey().getName();
+            String scope = key.substring(0, key.indexOf('#'));
+            String customPath = scopeToPath.get(scope);
+            if (customPath != null) {
+                perPathMethods.computeIfAbsent(customPath, k -> new HashMap<>())
+                        .put(entry.getKey(), entry.getValue());
+            } else {
+                defaultMethods.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // Default path OpenRPC document
+        OpenRPCDocumentGenerator defaultGenerator = new OpenRPCDocumentGenerator(
                 combinedIndexBuildItem.getIndex(), jsonRPCConfig.openrpc().schemaSimpleNames(),
                 jsonRPCConfig.openrpc().title(), jsonRPCConfig.openrpc().version());
-        String openrpcDocument = generator.generate(jsonRPCMethodsBuildItem.getMethodsMap());
+        String defaultDoc = defaultGenerator.generate(defaultMethods);
 
         routeProducer.produce(
                 httpRootPathBuildItem.routeBuilder()
                         .route(jsonRPCConfig.openrpc().path())
                         .routeConfigKey("quarkus.json-rpc.openrpc.path")
-                        .handler(recorder.openRpcHandler(openrpcDocument))
+                        .handler(recorder.openRpcHandler(defaultDoc))
                         .build());
+
+        // Per-path OpenRPC documents
+        for (Map.Entry<String, Map<JsonRPCMethodName, JsonRPCMethod>> pathEntry : perPathMethods.entrySet()) {
+            String customPath = pathEntry.getKey();
+            String openrpcPath = customPath + "/openrpc.json";
+
+            OpenRPCDocumentGenerator pathGenerator = new OpenRPCDocumentGenerator(
+                    combinedIndexBuildItem.getIndex(), jsonRPCConfig.openrpc().schemaSimpleNames(),
+                    jsonRPCConfig.openrpc().title(), jsonRPCConfig.openrpc().version());
+            String pathDoc = pathGenerator.generate(pathEntry.getValue());
+
+            routeProducer.produce(
+                    httpRootPathBuildItem.routeBuilder()
+                            .route(openrpcPath)
+                            .handler(recorder.openRpcHandler(pathDoc))
+                            .build());
+        }
     }
 
     @BuildStep
@@ -587,6 +624,8 @@ public class JsonRPCProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem) {
         CardPageBuildItem card = new CardPageBuildItem();
         IndexView index = combinedIndexBuildItem.getIndex();
+        Map<String, String> scopeToPath = jsonRPCMethodsBuildItem.getScopeToPath();
+        String defaultPath = jsonRPCConfig.webSocket().path();
 
         // Build-time data: registered methods table
         List<Map<String, Object>> methodsList = new ArrayList<>();
@@ -595,9 +634,14 @@ public class JsonRPCProcessor {
             JsonRPCMethodName methodName = entry.getKey();
             JsonRPCMethod method = entry.getValue();
 
-            methodData.put("key", methodName.getName());
+            String key = methodName.getName();
+            methodData.put("key", key);
             methodData.put("className", method.getClazz().getSimpleName());
             methodData.put("methodName", method.getMethodName());
+
+            String scope = key.substring(0, key.indexOf('#'));
+            String wsPath = scopeToPath.getOrDefault(scope, defaultPath);
+            methodData.put("path", wsPath);
 
             if (method.hasParams()) {
                 List<String> params = new ArrayList<>();
@@ -628,7 +672,7 @@ public class JsonRPCProcessor {
         }
         card.addBuildTimeData("methods", methodsList,
                 "All registered JSON-RPC methods with their signatures, execution modes, and security constraints", true);
-        card.addBuildTimeData("endpointPath", jsonRPCConfig.webSocket().path(),
+        card.addBuildTimeData("endpointPath", defaultPath,
                 "The WebSocket endpoint path for JSON-RPC connections", true);
 
         // Methods table page
@@ -649,12 +693,19 @@ public class JsonRPCProcessor {
                 .icon("font-awesome-solid:plug")
                 .componentLink("qwc-json-rpc-sessions.js"));
 
-        // OpenRPC schema viewer
+        // OpenRPC schema viewers
         if (jsonRPCConfig.openrpc().enabled()) {
             card.addPage(Page.externalPageBuilder("OpenRPC")
                     .url(jsonRPCConfig.openrpc().path())
                     .isJsonContent()
                     .icon("font-awesome-solid:file-code"));
+
+            for (String extraPath : jsonRPCMethodsBuildItem.getExtraPaths()) {
+                card.addPage(Page.externalPageBuilder("OpenRPC (" + extraPath + ")")
+                        .url(extraPath + "/openrpc.json")
+                        .isJsonContent()
+                        .icon("font-awesome-solid:file-code"));
+            }
         }
 
         return card;

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
@@ -49,6 +49,7 @@ export class QwcJsonRpcMethods extends LitElement {
                 <vaadin-grid-sort-column path="key" header="Key" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="className" header="Class" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="methodName" header="Method" auto-width resizable></vaadin-grid-sort-column>
+                <vaadin-grid-sort-column path="path" header="Path" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="parameters" header="Parameters" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="executionMode" header="Execution Mode" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-column header="Security" auto-width resizable

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
@@ -129,7 +129,7 @@ export class QwcJsonRpcTester extends LitElement {
 
     render() {
         return html`
-            <span class="endpoint-info">Endpoint: <code>${endpointPath}</code></span>
+            <span class="endpoint-info">Endpoint: <code>${this._selectedMethod?.path || endpointPath}</code></span>
 
             <div class="form-row">
                 <label>Method:</label>
@@ -235,7 +235,8 @@ export class QwcJsonRpcTester extends LitElement {
     _invokeViaWebSocket(params) {
         const loc = window.location;
         const wsProtocol = loc.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsUrl = `${wsProtocol}//${loc.host}${endpointPath}`;
+        const methodPath = this._selectedMethod?.path || endpointPath;
+        const wsUrl = `${wsProtocol}//${loc.host}${methodPath}`;
 
         const ws = new WebSocket(wsUrl);
         // Strip params suffix from the key — the server appends param names

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/CustomPathResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/CustomPathResource.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi(path = "/custom-rpc")
+public class CustomPathResource {
+
+    public String customHello() {
+        return "Hello from custom path [" + Thread.currentThread().getName() + "]";
+    }
+
+    public String customHello(String name) {
+        return "Hello " + name + " from custom path [" + Thread.currentThread().getName() + "]";
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/CustomPathResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/CustomPathResource.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.app;
 
 import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.mutiny.Multi;
 
 @JsonRPCApi(path = "/custom-rpc")
 public class CustomPathResource {
@@ -11,5 +12,9 @@ public class CustomPathResource {
 
     public String customHello(String name) {
         return "Hello " + name + " from custom path [" + Thread.currentThread().getName() + "]";
+    }
+
+    public Multi<String> customStream() {
+        return Multi.createFrom().items("custom-0", "custom-1", "custom-2");
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/app/InvalidPathResource.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/app/InvalidPathResource.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.jsonrpc.app;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+
+@JsonRPCApi(path = "no-leading-slash")
+public class InvalidPathResource {
+
+    public String hello() {
+        return "should not work";
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
@@ -1,7 +1,12 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -11,6 +16,7 @@ import io.quarkiverse.jsonrpc.app.CustomPathResource;
 import io.quarkiverse.jsonrpc.app.HelloResource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.json.JsonObject;
 
 public class CustomPathJsonRpcTest extends JsonRpcParent {
 
@@ -46,5 +52,67 @@ public class CustomPathJsonRpcTest extends JsonRpcParent {
         String result = getJsonRpcResponse(customRpcUri, "CustomPathResource#customHello",
                 Map.of("name", "Piet"));
         Assertions.assertTrue(result.startsWith("Hello Piet from custom path [executor-thread-"), result);
+    }
+
+    @Test
+    public void testCustomPathMethodCallableFromDefaultPath() throws Exception {
+        String result = getJsonRpcResponse("CustomPathResource#customHello");
+        Assertions.assertTrue(result.startsWith("Hello from custom path [executor-thread-"), result);
+    }
+
+    @Test
+    public void testMultiStreamOverCustomPath() throws Exception {
+        var client = vertx.createWebSocketClient();
+        try {
+            LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+            CompletableFuture<Void> connected = new CompletableFuture<>();
+            JsonObject request = JsonObject.of("jsonrpc", "2.0", "id", 1, "method", "CustomPathResource#customStream");
+
+            client.connect(customRpcUri.getPort(), customRpcUri.getHost(), customRpcUri.getPath())
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            var ws = r.result();
+                            ws.textMessageHandler(messages::add);
+                            ws.writeTextMessage(request.encode());
+                            connected.complete(null);
+                        } else {
+                            connected.completeExceptionally(r.cause());
+                        }
+                    });
+
+            connected.get(5, TimeUnit.SECONDS);
+
+            // Ack with subscription ID
+            String ackMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(ackMsg, "Expected ack message");
+            JsonObject ack = new JsonObject(ackMsg);
+            Assertions.assertEquals(1, ack.getInteger("id"));
+            String subscriptionId = ack.getString("result");
+            Assertions.assertNotNull(subscriptionId, "Ack result should be a subscription ID");
+
+            // 3 item notifications
+            List<String> items = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                String msg = messages.poll(10, TimeUnit.SECONDS);
+                Assertions.assertNotNull(msg, "Expected item notification " + i);
+                JsonObject json = new JsonObject(msg);
+                Assertions.assertEquals("subscription", json.getString("method"));
+                JsonObject params = json.getJsonObject("params");
+                Assertions.assertEquals(subscriptionId, params.getString("subscription"));
+                items.add(params.getString("result"));
+            }
+            Assertions.assertEquals(List.of("custom-0", "custom-1", "custom-2"), items);
+
+            // Completion notification
+            String completeMsg = messages.poll(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(completeMsg, "Expected completion notification");
+            JsonObject complete = new JsonObject(completeMsg);
+            Assertions.assertEquals("subscription", complete.getString("method"));
+            JsonObject completeParams = complete.getJsonObject("params");
+            Assertions.assertEquals(subscriptionId, completeParams.getString("subscription"));
+            Assertions.assertTrue(completeParams.getBoolean("complete"));
+        } finally {
+            client.close().toCompletionStage().toCompletableFuture().get();
+        }
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
@@ -55,9 +55,13 @@ public class CustomPathJsonRpcTest extends JsonRpcParent {
     }
 
     @Test
-    public void testCustomPathMethodCallableFromDefaultPath() throws Exception {
-        String result = getJsonRpcResponse("CustomPathResource#customHello");
-        Assertions.assertTrue(result.startsWith("Hello from custom path [executor-thread-"), result);
+    public void testCustomPathMethodNotCallableFromDefaultPath() throws Exception {
+        JsonObject response = getJsonRpcRawResponse("CustomPathResource#customHello");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response when calling custom-path method from default path");
+        Assertions.assertEquals(-32601, error.getInteger("code"));
+        Assertions.assertTrue(error.getString("message").contains("not found"),
+                "Error message should indicate method not found: " + error.getString("message"));
     }
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
@@ -65,6 +65,16 @@ public class CustomPathJsonRpcTest extends JsonRpcParent {
     }
 
     @Test
+    public void testDefaultPathMethodNotCallableFromCustomPath() throws Exception {
+        JsonObject response = getJsonRpcRawResponse(customRpcUri, "HelloResource#hello");
+        JsonObject error = response.getJsonObject("error");
+        Assertions.assertNotNull(error, "Expected error response when calling default-path method from custom path");
+        Assertions.assertEquals(-32601, error.getInteger("code"));
+        Assertions.assertTrue(error.getString("message").contains("not found"),
+                "Error message should indicate method not found: " + error.getString("message"));
+    }
+
+    @Test
     public void testMultiStreamOverCustomPath() throws Exception {
         var client = vertx.createWebSocketClient();
         try {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathJsonRpcTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.CustomPathResource;
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class CustomPathJsonRpcTest extends JsonRpcParent {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class, CustomPathResource.class);
+            });
+
+    @TestHTTPResource("custom-rpc")
+    URI customRpcUri;
+
+    @Test
+    public void testDefaultPathStillWorks() throws Exception {
+        String result = getJsonRpcResponse("HelloResource#hello");
+        Assertions.assertTrue(result.startsWith("Hello [executor-thread-"), result);
+    }
+
+    @Test
+    public void testDefaultPathWithParam() throws Exception {
+        String result = getJsonRpcResponse("HelloResource#hello", Map.of("name", "Koos"));
+        Assertions.assertTrue(result.startsWith("Hello Koos [executor-thread-"), result);
+    }
+
+    @Test
+    public void testCustomPathHello() throws Exception {
+        String result = getJsonRpcResponse(customRpcUri, "CustomPathResource#customHello");
+        Assertions.assertTrue(result.startsWith("Hello from custom path [executor-thread-"), result);
+    }
+
+    @Test
+    public void testCustomPathHelloWithParam() throws Exception {
+        String result = getJsonRpcResponse(customRpcUri, "CustomPathResource#customHello",
+                Map.of("name", "Piet"));
+        Assertions.assertTrue(result.startsWith("Hello Piet from custom path [executor-thread-"), result);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathOpenRPCTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathOpenRPCTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.deployment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,7 +39,7 @@ public class CustomPathOpenRPCTest extends JsClientTestBase {
         boolean hasCustom = methods.stream()
                 .map(o -> ((JsonObject) o).getString("name"))
                 .anyMatch(name -> name.startsWith("CustomPathResource#"));
-        assertTrue(!hasCustom, "Default OpenRPC should not contain CustomPathResource methods");
+        assertFalse(hasCustom, "Default OpenRPC should not contain CustomPathResource methods");
     }
 
     @Test
@@ -59,6 +60,6 @@ public class CustomPathOpenRPCTest extends JsClientTestBase {
         boolean hasHello = methods.stream()
                 .map(o -> ((JsonObject) o).getString("name"))
                 .anyMatch(name -> name.startsWith("HelloResource#"));
-        assertTrue(!hasHello, "Custom path OpenRPC should not contain HelloResource methods");
+        assertFalse(hasHello, "Custom path OpenRPC should not contain HelloResource methods");
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathOpenRPCTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/CustomPathOpenRPCTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.CustomPathResource;
+import io.quarkiverse.jsonrpc.app.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class CustomPathOpenRPCTest extends JsClientTestBase {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(HelloResource.class, CustomPathResource.class);
+            });
+
+    @Test
+    public void testDefaultOpenRPCContainsOnlyDefaultMethods() throws Exception {
+        String body = httpGet("/json-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+        assertEquals("1.3.2", doc.getString("openrpc"));
+
+        JsonArray methods = doc.getJsonArray("methods");
+        assertNotNull(methods);
+
+        boolean hasHello = methods.stream()
+                .map(o -> ((JsonObject) o).getString("name"))
+                .anyMatch(name -> name.startsWith("HelloResource#"));
+        assertTrue(hasHello, "Default OpenRPC should contain HelloResource methods");
+
+        boolean hasCustom = methods.stream()
+                .map(o -> ((JsonObject) o).getString("name"))
+                .anyMatch(name -> name.startsWith("CustomPathResource#"));
+        assertTrue(!hasCustom, "Default OpenRPC should not contain CustomPathResource methods");
+    }
+
+    @Test
+    public void testCustomPathOpenRPCContainsOnlyCustomMethods() throws Exception {
+        String body = httpGet("/custom-rpc/openrpc.json");
+        JsonObject doc = new JsonObject(body);
+        assertEquals("1.3.2", doc.getString("openrpc"));
+
+        JsonArray methods = doc.getJsonArray("methods");
+        assertNotNull(methods);
+        assertTrue(methods.size() > 0, "Custom path OpenRPC should contain methods");
+
+        boolean hasCustom = methods.stream()
+                .map(o -> ((JsonObject) o).getString("name"))
+                .anyMatch(name -> name.startsWith("CustomPathResource#"));
+        assertTrue(hasCustom, "Custom path OpenRPC should contain CustomPathResource methods");
+
+        boolean hasHello = methods.stream()
+                .map(o -> ((JsonObject) o).getString("name"))
+                .anyMatch(name -> name.startsWith("HelloResource#"));
+        assertTrue(!hasHello, "Custom path OpenRPC should not contain HelloResource methods");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/InvalidPathValidationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/InvalidPathValidationTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.jsonrpc.deployment;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.jsonrpc.app.InvalidPathResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InvalidPathValidationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidPathResource.class);
+            })
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof IllegalArgumentException,
+                        "Expected IllegalArgumentException but got: " + t.getClass().getName());
+                Assertions.assertTrue(
+                        t.getMessage().contains("must start with '/'"),
+                        "Expected message about leading slash but got: " + t.getMessage());
+            });
+
+    @Test
+    public void testValidationFails() {
+        Assertions.fail("Should not reach here — build should have failed");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
@@ -58,7 +58,7 @@ public class JsonRpcParent {
 
     protected <T> T getJsonRpcResponse(String providedInput, Class<T> responseType, Object[] params) throws Exception {
         int id = count.incrementAndGet();
-        return jsonRpcResponse(id, responseType, (ws, queue) -> {
+        return jsonRpcResponse(jsonRpcUri, id, responseType, (ws, queue) -> {
             ws.textMessageHandler(msg -> {
                 queue.add(msg);
             });
@@ -73,7 +73,26 @@ public class JsonRpcParent {
     protected <T> T getJsonRpcResponse(String providedInput, Class<T> responseType, Map<String, Object> params)
             throws Exception {
         int id = count.incrementAndGet();
-        return jsonRpcResponse(id, responseType, (ws, queue) -> {
+        return jsonRpcResponse(jsonRpcUri, id, responseType, (ws, queue) -> {
+            ws.textMessageHandler(msg -> {
+                queue.add(msg);
+            });
+            ws.writeTextMessage(getJsonRPCRequest(id, providedInput, params));
+        });
+    }
+
+    protected String getJsonRpcResponse(URI uri, String providedInput) throws Exception {
+        return getJsonRpcResponse(uri, providedInput, String.class, Map.of());
+    }
+
+    protected String getJsonRpcResponse(URI uri, String providedInput, Map<String, Object> params) throws Exception {
+        return getJsonRpcResponse(uri, providedInput, String.class, params);
+    }
+
+    protected <T> T getJsonRpcResponse(URI uri, String providedInput, Class<T> responseType, Map<String, Object> params)
+            throws Exception {
+        int id = count.incrementAndGet();
+        return jsonRpcResponse(uri, id, responseType, (ws, queue) -> {
             ws.textMessageHandler(msg -> {
                 queue.add(msg);
             });
@@ -83,11 +102,16 @@ public class JsonRpcParent {
 
     private JsonObject jsonRpcRawResponse(int expectedId, BiConsumer<WebSocket, Queue<String>> action)
             throws Exception {
+        return jsonRpcRawResponse(jsonRpcUri, expectedId, action);
+    }
+
+    private JsonObject jsonRpcRawResponse(URI uri, int expectedId, BiConsumer<WebSocket, Queue<String>> action)
+            throws Exception {
         WebSocketClient client = vertx.createWebSocketClient();
         try {
             LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
             client
-                    .connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .connect(uri.getPort(), uri.getHost(), uri.getPath())
                     .onComplete(r -> {
                         if (r.succeeded()) {
                             WebSocket ws = r.result();
@@ -108,13 +132,14 @@ public class JsonRpcParent {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T jsonRpcResponse(int expectedId, Class<T> responseType, BiConsumer<WebSocket, Queue<String>> action)
+    private <T> T jsonRpcResponse(URI uri, int expectedId, Class<T> responseType,
+            BiConsumer<WebSocket, Queue<String>> action)
             throws Exception {
         WebSocketClient client = vertx.createWebSocketClient();
         try {
             LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
             client
-                    .connect(jsonRpcUri.getPort(), jsonRpcUri.getHost(), jsonRpcUri.getPath())
+                    .connect(uri.getPort(), uri.getHost(), uri.getPath())
                     .onComplete(r -> {
                         if (r.succeeded()) {
                             WebSocket ws = r.result();

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsonRpcParent.java
@@ -100,6 +100,21 @@ public class JsonRpcParent {
         });
     }
 
+    protected JsonObject getJsonRpcRawResponse(URI uri, String providedInput) throws Exception {
+        return getJsonRpcRawResponse(uri, providedInput, Map.of());
+    }
+
+    protected JsonObject getJsonRpcRawResponse(URI uri, String providedInput, Map<String, Object> params)
+            throws Exception {
+        int id = count.incrementAndGet();
+        return jsonRpcRawResponse(uri, id, (ws, queue) -> {
+            ws.textMessageHandler(msg -> {
+                queue.add(msg);
+            });
+            ws.writeTextMessage(getJsonRPCRequest(id, providedInput, params));
+        });
+    }
+
     private JsonObject jsonRpcRawResponse(int expectedId, BiConsumer<WebSocket, Queue<String>> action)
             throws Exception {
         return jsonRpcRawResponse(jsonRpcUri, expectedId, action);

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -145,15 +145,75 @@ If the client _does_ include an `id`, the server responds with `"result": null` 
 
 Void methods follow the same execution mode rules as any other method — they are blocking by default and can be annotated with `@NonBlocking` or `@RunOnVirtualThread`. See xref:guides-execution-modes.adoc[Execution Modes & Return Types].
 
+== Custom Path
+
+By default, all `@JsonRPCApi` classes share the global WebSocket endpoint (see <<websocket-endpoint>> below). You can assign a class to a separate WebSocket path using the `path` attribute:
+
+[source,java]
+----
+@JsonRPCApi(path = "/admin-rpc")
+public class AdminService {
+
+    public String getStatus() {
+        return "OK";
+    }
+}
+----
+
+This registers an additional WebSocket route at `/admin-rpc`. The methods on `AdminService` are accessible through both the custom path and the default global path.
+
+You can combine `path` with a custom scope:
+
+[source,java]
+----
+@JsonRPCApi(value = "admin", path = "/admin-rpc")
+public class AdminService {
+
+    public String getStatus() {
+        return "OK";
+    }
+}
+----
+
+Now the method is called as `admin#getStatus` via the `/admin-rpc` WebSocket endpoint.
+
+=== Multiple API Groups
+
+Different classes can use different paths, enabling logical separation:
+
+[source,java]
+----
+@JsonRPCApi(path = "/admin-rpc")
+public class AdminService {
+    public String getStatus() { ... }
+}
+
+@JsonRPCApi(path = "/public-rpc")
+public class PublicService {
+    public String getInfo() { ... }
+}
+
+@JsonRPCApi
+public class DefaultService {
+    public String hello() { ... } // <1>
+}
+----
+<1> No `path` — served on the default global endpoint (`/json-rpc`).
+
+This is useful for applying different security policies per path. See xref:guides-security.adoc#_per_path_security[Security — Per-Path Security] for details.
+
+[#websocket-endpoint]
 == WebSocket Endpoint
 
-All JSON-RPC methods are served through a single WebSocket endpoint. By default, this is:
+By default, all JSON-RPC methods are served through a WebSocket endpoint at:
 
 ----
 ws://localhost:8080/json-rpc
 ----
 
-See xref:reference-configuration.adoc[Configuration Reference] to change the path.
+Classes with a `path` attribute register additional WebSocket routes at their specified paths. Classes without a `path` are served on the default global endpoint.
+
+See xref:reference-configuration.adoc[Configuration Reference] to change the default path.
 
 == JSON-RPC 2.0 Protocol
 

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -160,7 +160,7 @@ public class AdminService {
 }
 ----
 
-This registers an additional WebSocket route at `/admin-rpc`. The methods on `AdminService` are accessible through both the custom path and the default global path.
+This registers an additional WebSocket route at `/admin-rpc`. The methods on `AdminService` are _only_ accessible through the custom path — clients connected to the default global endpoint will receive a "method not found" error if they try to call `AdminService` methods.
 
 You can combine `path` with a custom scope:
 
@@ -211,7 +211,7 @@ By default, all JSON-RPC methods are served through a WebSocket endpoint at:
 ws://localhost:8080/json-rpc
 ----
 
-Classes with a `path` attribute register additional WebSocket routes at their specified paths. Classes without a `path` are served on the default global endpoint.
+Classes with a `path` attribute register additional WebSocket routes at their specified paths and are only callable from those paths. Classes without a `path` are served exclusively on the default global endpoint.
 
 See xref:reference-configuration.adoc[Configuration Reference] to change the default path.
 

--- a/docs/modules/ROOT/pages/guides-javascript-client.adoc
+++ b/docs/modules/ROOT/pages/guides-javascript-client.adoc
@@ -78,6 +78,40 @@ const sub = TickerService.ticker()
 await sub.cancel();
 ----
 
+=== Custom Path APIs
+
+When `@JsonRPCApi(path = "...")` is used, the generated proxy creates a separate `JsonRPCClient` for each unique custom path. Scopes without a custom path use the default `client`:
+
+[source,java]
+----
+@JsonRPCApi(path = "/admin-rpc")
+public class AdminService { ... }
+
+@JsonRPCApi
+public class PublicService { ... }
+----
+
+[source,javascript]
+----
+import { client, AdminService, PublicService } from '@quarkiverse/json-rpc-api';
+
+// PublicService calls go through the default client at /json-rpc
+const info = await PublicService.getInfo();
+
+// AdminService calls go through a separate client at /admin-rpc
+const status = await AdminService.getStatus();
+----
+
+Each custom-path client is created internally and used automatically by the proxy. If you need to configure authentication or connection settings for a custom-path client, use `JsonRPCClient.configure()` to set global defaults that apply to all client instances:
+
+[source,javascript]
+----
+import { JsonRPCClient } from '@quarkiverse/json-rpc';
+
+// Applies to all clients (default and custom-path)
+JsonRPCClient.configure({ token: 'Bearer my-jwt-token' });
+----
+
 === Configuring the Connection
 
 The typed proxy exports the `client` instance so you can reconfigure the WebSocket URL at runtime -- for example, when behind a reverse proxy or gateway:

--- a/docs/modules/ROOT/pages/guides-openrpc.adoc
+++ b/docs/modules/ROOT/pages/guides-openrpc.adoc
@@ -124,6 +124,21 @@ Streaming types (`Multi<T>`, `Flow.Publisher<T>`) are also unwrapped, and the me
 }
 ----
 
+== Custom Path APIs
+
+When `@JsonRPCApi(path = "...")` is used, separate OpenRPC documents are generated for each WebSocket path. The default document at `/json-rpc/openrpc.json` contains only methods served on the default path. Each custom path gets its own document:
+
+[source,shell]
+----
+# Methods on the default /json-rpc path
+curl http://localhost:8080/json-rpc/openrpc.json
+
+# Methods on /admin-rpc
+curl http://localhost:8080/admin-rpc/openrpc.json
+----
+
+This ensures each OpenRPC document accurately reflects the methods available on its corresponding WebSocket endpoint.
+
 == Dev UI
 
 During development, the OpenRPC document is also available in the Quarkus Dev UI. The JSON-RPC card includes an "OpenRPC" page that displays the full document with syntax highlighting.

--- a/docs/modules/ROOT/pages/guides-security.adoc
+++ b/docs/modules/ROOT/pages/guides-security.adoc
@@ -159,9 +159,13 @@ quarkus.http.auth.permission.public-rpc.paths=/public-rpc
 quarkus.http.auth.permission.public-rpc.policy=permit
 ----
 
-This provides two layers of security isolation: unauthenticated users cannot even establish a WebSocket connection to `/admin-rpc`, and individual methods are further protected by `@RolesAllowed` annotations.
+This provides two layers of security isolation:
 
-IMPORTANT: Path-based HTTP policies control who can _connect_ to a WebSocket endpoint. Once connected to any endpoint, all registered JSON-RPC methods are callable regardless of which path the client connected through. Always use `@RolesAllowed` or other method-level security annotations to protect sensitive methods — do not rely on path-based HTTP policies alone.
+1. *Path isolation* — methods declared with `@JsonRPCApi(path = "/admin-rpc")` are only callable from the `/admin-rpc` WebSocket endpoint. A client connected to `/public-rpc` cannot invoke `AdminService` methods.
+2. *Connection-level auth* — unauthenticated users cannot even establish a WebSocket connection to `/admin-rpc`.
+3. *Method-level auth* — individual methods are further protected by `@RolesAllowed` annotations as defense-in-depth.
+
+TIP: While path isolation prevents cross-path method calls, using `@RolesAllowed` or other method-level security annotations is still recommended as defense-in-depth.
 
 See xref:guides-creating-api.adoc#_custom_path[Creating an API — Custom Path] for details on the `path` attribute.
 

--- a/docs/modules/ROOT/pages/guides-security.adoc
+++ b/docs/modules/ROOT/pages/guides-security.adoc
@@ -128,6 +128,41 @@ quarkus.http.auth.permission.json-rpc.policy=role-policy
 quarkus.http.auth.policy.role-policy.roles-allowed=admin,operator
 ----
 
+[#_per_path_security]
+== Per-Path Security
+
+When using `@JsonRPCApi(path = "...")` to serve different API groups on separate WebSocket paths, you can apply distinct HTTP auth policies to each path:
+
+[source,java]
+----
+@JsonRPCApi(path = "/admin-rpc")
+@RolesAllowed("admin")
+public class AdminService {
+    public String getSecretData() { ... }
+}
+
+@JsonRPCApi(path = "/public-rpc")
+public class PublicService {
+    public String getInfo() { ... }
+}
+----
+
+[source,properties]
+----
+# Require admin role to connect to /admin-rpc
+quarkus.http.auth.permission.admin-rpc.paths=/admin-rpc
+quarkus.http.auth.permission.admin-rpc.policy=admin-policy
+quarkus.http.auth.policy.admin-policy.roles-allowed=admin
+
+# Allow anyone to connect to /public-rpc
+quarkus.http.auth.permission.public-rpc.paths=/public-rpc
+quarkus.http.auth.permission.public-rpc.policy=permit
+----
+
+This provides two layers of security isolation: unauthenticated users cannot even establish a WebSocket connection to `/admin-rpc`, and individual methods are further protected by `@RolesAllowed` annotations.
+
+See xref:guides-creating-api.adoc#_custom_path[Creating an API — Custom Path] for details on the `path` attribute.
+
 == Combining Both Approaches
 
 Annotations and HTTP policies can be combined:

--- a/docs/modules/ROOT/pages/guides-security.adoc
+++ b/docs/modules/ROOT/pages/guides-security.adoc
@@ -161,6 +161,8 @@ quarkus.http.auth.permission.public-rpc.policy=permit
 
 This provides two layers of security isolation: unauthenticated users cannot even establish a WebSocket connection to `/admin-rpc`, and individual methods are further protected by `@RolesAllowed` annotations.
 
+IMPORTANT: Path-based HTTP policies control who can _connect_ to a WebSocket endpoint. Once connected to any endpoint, all registered JSON-RPC methods are callable regardless of which path the client connected through. Always use `@RolesAllowed` or other method-level security annotations to protect sensitive methods — do not rely on path-based HTTP policies alone.
+
 See xref:guides-creating-api.adoc#_custom_path[Creating an API — Custom Path] for details on the `path` attribute.
 
 == Combining Both Approaches

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCApi.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/api/JsonRPCApi.java
@@ -8,7 +8,6 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a class as a Json-RPC Endpoint.
- * TODO: Allow adding path (from ws)?
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -18,4 +17,13 @@ public @interface JsonRPCApi {
      * @return a identifier/scope
      */
     String value() default "_DEFAULT_SCOPE_";
+
+    /**
+     * Optional WebSocket path for this API group.
+     * When set, a separate WebSocket route is registered at this path
+     * in addition to the default global path.
+     * When left empty (default), the class's methods are served on the
+     * global path configured via {@code quarkus.json-rpc.web-socket.path}.
+     */
+    String path() default "";
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.jsonrpc.runtime;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -79,8 +80,8 @@ public class JsonRPCRecorder {
         return new JsonRPCWebSocket(beanContainer.beanInstance(JsonRPCRouter.class));
     }
 
-    public Handler<RoutingContext> subProtocolHandler(String wsPath) {
-        return new JsonRPCSubProtocolHandler(wsPath);
+    public Handler<RoutingContext> subProtocolHandler(Set<String> wsPaths) {
+        return new JsonRPCSubProtocolHandler(wsPaths);
     }
 
     public Handler<RoutingContext> openRpcHandler(String openrpcDocument) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -52,7 +52,8 @@ public class JsonRPCRecorder {
     }
 
     public Function<SyntheticCreationalContext<JsonRPCRouter>, JsonRPCRouter> createJsonRpcRouter(
-            Map<JsonRPCMethodName, JsonRPCMethod> methodsMap) {
+            Map<JsonRPCMethodName, JsonRPCMethod> methodsMap,
+            Map<String, String> scopeToPath, String defaultPath) {
         return new Function<>() {
             @Override
             public JsonRPCRouter apply(SyntheticCreationalContext<JsonRPCRouter> context) {
@@ -60,6 +61,7 @@ public class JsonRPCRecorder {
                         context.getInjectedReference(JsonRPCCodec.class),
                         context.getInjectedReference(JsonRPCSessions.class),
                         methodsMap,
+                        scopeToPath, defaultPath,
                         runtimeConfig.getValue().methodTimeout().orElse(null));
             }
         };

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -72,16 +72,20 @@ public class JsonRPCRouter {
 
     private final Map<String, String> orderedParameterKeyToNamedKey = new HashMap<>();
 
+    private final Map<String, String> methodKeyToAllowedPath = new HashMap<>();
+
     private final JsonRPCSessions sessions;
 
     private final Duration methodTimeout;
 
     public JsonRPCRouter(JsonRPCCodec codec, JsonRPCSessions sessions,
-            Map<JsonRPCMethodName, JsonRPCMethod> methodsMap, Duration methodTimeout) {
+            Map<JsonRPCMethodName, JsonRPCMethod> methodsMap,
+            Map<String, String> scopeToPath, String defaultPath,
+            Duration methodTimeout) {
         this.codec = codec;
         this.sessions = sessions;
         this.methodTimeout = methodTimeout;
-        populateJsonRPCMethods(methodsMap);
+        populateJsonRPCMethods(methodsMap, scopeToPath, defaultPath);
     }
 
     private static JsonRPCMetricsHandler metrics() {
@@ -93,7 +97,8 @@ public class JsonRPCRouter {
      *
      * @param methodsMap
      */
-    private void populateJsonRPCMethods(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap) {
+    private void populateJsonRPCMethods(Map<JsonRPCMethodName, JsonRPCMethod> methodsMap,
+            Map<String, String> scopeToPath, String defaultPath) {
         for (Map.Entry<JsonRPCMethodName, JsonRPCMethod> method : methodsMap.entrySet()) {
             JsonRPCMethodName methodName = method.getKey();
             JsonRPCMethod jsonRpcMethod = method.getValue();
@@ -113,10 +118,14 @@ public class JsonRPCRouter {
                 }
                 ReflectionInfo reflectionInfo = new ReflectionInfo(jsonRpcMethod.getClazz(), providerInstance, javaMethod,
                         params, jsonRpcMethod.getExecutionMode());
-                jsonRpcToJava.put(methodName.toString(), reflectionInfo);
+                String key = methodName.toString();
+                jsonRpcToJava.put(key, reflectionInfo);
                 if (methodName.hasOrderedParameterKey()) {
-                    orderedParameterKeyToNamedKey.put(methodName.getOrderedParameterKey(), methodName.toString());
+                    orderedParameterKeyToNamedKey.put(methodName.getOrderedParameterKey(), key);
                 }
+
+                String scope = key.substring(0, key.indexOf('#'));
+                methodKeyToAllowedPath.put(key, scopeToPath.getOrDefault(scope, defaultPath));
             } catch (NoSuchMethodException | SecurityException ex) {
                 throw new RuntimeException(ex);
             }
@@ -437,6 +446,12 @@ public class JsonRPCRouter {
         }
 
         if (this.jsonRpcToJava.containsKey(key)) {
+            String allowedPath = methodKeyToAllowedPath.get(key);
+            if (allowedPath != null && !allowedPath.equals(s.path())) {
+                return Uni.createFrom().item(new DispatchResult(new JsonRPCResponse<>(jsonRpcRequest.getId(),
+                        new JsonRPCResponse.Error(JsonRPCKeys.METHOD_NOT_FOUND,
+                                "Method [" + jsonRpcRequest.getMethod() + "] not found"))));
+            }
             ReflectionInfo reflectionInfo = this.jsonRpcToJava.get(key);
             Object target = Arc.container().select(reflectionInfo.bean).get();
             String methodName = jsonRpcRequest.getMethod();

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSubProtocolHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCSubProtocolHandler.java
@@ -42,15 +42,15 @@ public class JsonRPCSubProtocolHandler implements Handler<RoutingContext> {
 
     private static final Set<String> ALLOWED_HEADERS = Set.of("authorization");
 
-    private final String wsPath;
+    private final Set<String> wsPaths;
 
-    public JsonRPCSubProtocolHandler(String wsPath) {
-        this.wsPath = wsPath;
+    public JsonRPCSubProtocolHandler(Set<String> wsPaths) {
+        this.wsPaths = wsPaths;
     }
 
     @Override
     public void handle(RoutingContext event) {
-        if (!event.request().path().equals(wsPath)) {
+        if (!wsPaths.contains(event.request().path())) {
             event.next();
             return;
         }

--- a/sample/src/main/java/io/quarkiverse/jsonrpc/sample/CustomPathResource.java
+++ b/sample/src/main/java/io/quarkiverse/jsonrpc/sample/CustomPathResource.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.jsonrpc.sample;
+
+import io.quarkiverse.jsonrpc.api.JsonRPCApi;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@JsonRPCApi(path = "/custom-rpc")
+public class CustomPathResource {
+
+    public String hello() {
+        return "Hello from custom path [" + Thread.currentThread().getName() + "]";
+    }
+
+    public String hello(String name) {
+        return "Hello " + name + " from custom path [" + Thread.currentThread().getName() + "]";
+    }
+
+    public Uni<String> helloUni() {
+        return Uni.createFrom().item(hello());
+    }
+
+    public Multi<String> helloMulti() {
+        return Multi.createFrom().items("custom-0", "custom-1", "custom-2");
+    }
+}


### PR DESCRIPTION
Adds an optional `path` attribute to `@JsonRPCApi` so that annotated classes can declare their own WebSocket endpoint path. Classes without a `path` continue to use the global config-based path, preserving full backward compatibility.

The approach uses a single shared `JsonRPCRouter` with multiple Vert.x routes — the router dispatches by method key (`scope#method`), so namespace isolation is already built in. Separate routes enable path-based HTTP auth policies for security isolation (e.g. `/admin-rpc` vs `/public-rpc`).

```java
@JsonRPCApi(path = "/admin-rpc")
public class AdminService { ... }

@JsonRPCApi
public class PublicService { ... }
```

Changes:
- `@JsonRPCApi` annotation gains `String path() default ""`
- Build-time processor collects custom paths, registers extra WebSocket routes, and generates per-path JS client instances
- Sub-protocol filter updated to handle multiple paths
- Documentation updated across creating-api, security, and JavaScript client guides

Closes #133