### PR TITLE
Move RAG docs to separate artifact and index all pages

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -10,10 +10,6 @@
     <artifactId>quarkus-json-rpc-deployment</artifactId>
     <name>Quarkus Json Rpc - Deployment</name>
 
-    <properties>
-        <quarkus-rag.guide>${project.basedir}/../docs/modules/ROOT/pages/index.adoc</quarkus-rag.guide>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
+++ b/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
@@ -1,0 +1,2 @@
+groupId=io.quarkiverse.json-rpc
+artifactId=quarkus-json-rpc-rag

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>deployment</module>
         <module>runtime</module>
         <module>sample</module>
+        <module>rag</module>
     </modules>
 
     <scm>

--- a/rag/pom.xml
+++ b/rag/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.json-rpc</groupId>
+        <artifactId>quarkus-json-rpc-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-json-rpc-rag</artifactId>
+    <name>Quarkus Json Rpc - RAG</name>
+    <description>RAG vector embeddings for Quarkus JSON-RPC documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../docs/modules/ROOT/pages</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>rag</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
Replaces the existing single-page RAG config (`quarkus-rag.guide` pointing to just `index.adoc`, producing only 4 chunks) with a dedicated `rag` module that indexes all 16 documentation pages (107 chunks, 236K artifact).

- Removed `quarkus-rag.guide` property from deployment pom — RAG SQL is no longer bundled in the deployment JAR
- Added pointer file `META-INF/quarkus-rag-artifact.properties` to tell the loader where to find the separate RAG artifact
- Deployment JAR stays at 52K (unchanged)

This gives AI assistants 26x more searchable documentation content while keeping the deployment JAR small.

Depends on quarkusio/quarkus-agent-mcp#215 and chappie-bot/chappie-server#43 for the loader-side pointer file support.