### PR TITLE
Fix JS client breaking behind path-prefix reverse proxy

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -480,7 +480,8 @@ public class JsonRPCProcessor {
             Map<String, String> scopeToPath) {
         StringBuilder js = new StringBuilder();
         js.append("import { JsonRPCClient } from '@quarkiverse/json-rpc';\n\n");
-        js.append("export const client = new JsonRPCClient({ path: '").append(escapeJsString(wsPath)).append("' });\n\n");
+        js.append("export const client = new JsonRPCClient({ path: '").append(escapeJsString(wsPath))
+                .append("', autoConnect: false });\n\n");
 
         // Create additional clients for custom paths
         Set<String> extraPaths = new TreeSet<>(scopeToPath.values());
@@ -489,7 +490,7 @@ public class JsonRPCProcessor {
             String varName = pathToClientVar(path);
             pathToClientVar.put(path, varName);
             js.append("const ").append(varName).append(" = new JsonRPCClient({ path: '")
-                    .append(escapeJsString(path)).append("' });\n");
+                    .append(escapeJsString(path)).append("', autoConnect: false });\n");
         }
         if (!extraPaths.isEmpty()) {
             js.append("\n");

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -149,6 +149,7 @@ export class JsonRPCClient {
         this._ws = ws;
 
         ws.onopen = () => {
+            if (this._ws !== ws) return;
             this._connected = true;
             this._reconnectDelay = 1000;
             while (this._queue.length > 0) {
@@ -158,6 +159,7 @@ export class JsonRPCClient {
         };
 
         ws.onclose = (event) => {
+            if (this._ws !== ws) return;
             this._connected = false;
             this._ws = null;
 
@@ -187,10 +189,12 @@ export class JsonRPCClient {
         };
 
         ws.onerror = (error) => {
+            if (this._ws !== ws) return;
             if (this.onError) this.onError(error);
         };
 
         ws.onmessage = (event) => {
+            if (this._ws !== ws) return;
             try {
                 this._handleMessage(JSON.parse(event.data));
             } catch (e) {

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -26,6 +26,7 @@ export class JsonRPCClient {
     _pending = new Map();
     _subscriptions = new Map();
     _listeners = new Map();
+    _queue = [];
     _autoReconnect;
     _reconnectDelay;
     _maxReconnectDelay;
@@ -67,8 +68,15 @@ export class JsonRPCClient {
     set url(value) {
         const changed = this._url !== value;
         this._url = value;
-        if (changed && this._ws) {
-            this.disconnect();
+        if (changed && !this._manuallyDisconnected) {
+            if (this._reconnectTimer) {
+                clearTimeout(this._reconnectTimer);
+                this._reconnectTimer = null;
+            }
+            if (this._ws) {
+                this._ws.close();
+                this._ws = null;
+            }
             this.connect();
         }
     }
@@ -80,8 +88,15 @@ export class JsonRPCClient {
     set path(value) {
         const changed = this._path !== value;
         this._path = value;
-        if (changed && this._ws && !this._url) {
-            this.disconnect();
+        if (changed && !this._url && !this._manuallyDisconnected) {
+            if (this._reconnectTimer) {
+                clearTimeout(this._reconnectTimer);
+                this._reconnectTimer = null;
+            }
+            if (this._ws) {
+                this._ws.close();
+                this._ws = null;
+            }
             this.connect();
         }
     }
@@ -136,6 +151,9 @@ export class JsonRPCClient {
         ws.onopen = () => {
             this._connected = true;
             this._reconnectDelay = 1000;
+            while (this._queue.length > 0) {
+                ws.send(JSON.stringify(this._queue.shift()));
+            }
             if (this.onOpen) this.onOpen();
         };
 
@@ -183,6 +201,7 @@ export class JsonRPCClient {
 
     disconnect() {
         this._manuallyDisconnected = true;
+        this._queue.length = 0;
         if (this._reconnectTimer) {
             clearTimeout(this._reconnectTimer);
             this._reconnectTimer = null;
@@ -266,10 +285,7 @@ export class JsonRPCClient {
     notify(method, params) {
         const msg = { jsonrpc: '2.0', method };
         if (params != null) msg.params = params;
-        if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
-            throw new Error('WebSocket not connected');
-        }
-        this._ws.send(JSON.stringify(msg));
+        this._send(msg);
     }
 
     /**
@@ -304,11 +320,10 @@ export class JsonRPCClient {
     _send(message) {
         if (this._ws && this._ws.readyState === WebSocket.OPEN) {
             this._ws.send(JSON.stringify(message));
-        } else if (message.id !== undefined) {
-            const pending = this._pending.get(message.id);
-            if (pending) {
-                this._pending.delete(message.id);
-                pending.reject(new Error('WebSocket not connected'));
+        } else {
+            this._queue.push(message);
+            if (!this._ws && !this._manuallyDisconnected) {
+                this.connect();
             }
         }
     }

--- a/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
+++ b/deployment/src/main/resources/jsonrpc/jsonrpc-client.js
@@ -69,15 +69,7 @@ export class JsonRPCClient {
         const changed = this._url !== value;
         this._url = value;
         if (changed && !this._manuallyDisconnected) {
-            if (this._reconnectTimer) {
-                clearTimeout(this._reconnectTimer);
-                this._reconnectTimer = null;
-            }
-            if (this._ws) {
-                this._ws.close();
-                this._ws = null;
-            }
-            this.connect();
+            this._reconnectToNewUrl();
         }
     }
 
@@ -89,15 +81,7 @@ export class JsonRPCClient {
         const changed = this._path !== value;
         this._path = value;
         if (changed && !this._url && !this._manuallyDisconnected) {
-            if (this._reconnectTimer) {
-                clearTimeout(this._reconnectTimer);
-                this._reconnectTimer = null;
-            }
-            if (this._ws) {
-                this._ws.close();
-                this._ws = null;
-            }
-            this.connect();
+            this._reconnectToNewUrl();
         }
     }
 
@@ -319,6 +303,26 @@ export class JsonRPCClient {
             'quarkus-http-upgrade#Authorization#' + token
         );
         return ['bearer-token-carrier', encoded];
+    }
+
+    _reconnectToNewUrl() {
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+        if (this._ws) {
+            for (const [, pending] of this._pending) {
+                pending.reject(new Error('WebSocket URL changed'));
+            }
+            this._pending.clear();
+            for (const [, sub] of this._subscriptions) {
+                sub._push('error', new Error('WebSocket URL changed'));
+            }
+            this._subscriptions.clear();
+            this._ws.close();
+            this._ws = null;
+        }
+        this.connect();
     }
 
     _send(message) {

--- a/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/jsonrpc/deployment/JsClientGenerationTest.java
@@ -38,8 +38,9 @@ public class JsClientGenerationTest extends JsClientTestBase {
         String body = httpGet("/_static/quarkus-json-rpc-api/jsonrpc-api.js");
         Assertions.assertTrue(body.contains("import { JsonRPCClient } from '@quarkiverse/json-rpc'"),
                 "Proxy should import using bare import specifier");
-        Assertions.assertTrue(body.contains("export const client = new JsonRPCClient({ path: '/json-rpc' })"),
-                "Proxy should export a client instance with configured path");
+        Assertions.assertTrue(
+                body.contains("export const client = new JsonRPCClient({ path: '/json-rpc', autoConnect: false })"),
+                "Proxy should export a client instance with configured path and deferred connect");
     }
 
     @Test

--- a/sample/src/main/resources/web/app/jsonrpc-app.js
+++ b/sample/src/main/resources/web/app/jsonrpc-app.js
@@ -214,6 +214,7 @@ class JsonRpcApp extends LitElement {
             this._connected = false;
             this._subscriptions = new Map();
         };
+        client.connect();
         this._connected = client.connected;
     }
 


### PR DESCRIPTION
The generated typed proxy (`jsonrpc-api.js`) eagerly connects at ES module evaluation time — before consumer code can override the WebSocket URL. When deployed behind a reverse proxy with a path prefix (e.g. `/<service>/*`), the client connects to `wss://host/json-rpc` instead of `wss://host/<prefix>/json-rpc`, causing a 404 loop.

Three changes fix this:

- **Lazy connect via message queueing** — `_send()` now buffers messages and triggers `connect()` on first use instead of rejecting. The queue is flushed when the socket opens. The generated proxy passes `autoConnect: false` so no connection opens at import time; the first `call()`/`subscribe()`/`notify()` initiates the connection.

- **Robust `url`/`path` setters** — The setters now cancel pending reconnect timers and reconnect even when `_ws` is `null` (which happens after a failed connection closes the socket). This ensures consumer URL overrides reliably take effect regardless of the prior connection state.

- **`notify()` uses `_send()`** — Instead of throwing synchronously when not connected, `notify()` now delegates to `_send()`, giving it the same queue-and-lazy-connect behavior as `call()` and `subscribe()`.

Fixes #158