### PR TITLE
Improve Dev UI tester and add JSON-RPC message log to footer

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jsonrpc/deployment/JsonRPCProcessor.java
@@ -65,6 +65,7 @@ import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.FooterPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
@@ -749,6 +750,22 @@ public class JsonRPCProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     JsonRPCProvidersBuildItem createDevUIJsonRPCService() {
         return new JsonRPCProvidersBuildItem(JsonRPCDevUIService.class);
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void enableMessageLog(JsonRPCRecorder recorder, BeanContainerBuildItem beanContainer) {
+        recorder.enableMessageLog(beanContainer.getValue());
+    }
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    FooterPageBuildItem createFooterLog() {
+        FooterPageBuildItem footer = new FooterPageBuildItem();
+        footer.addPage(Page.webComponentPageBuilder()
+                .title("JSON-RPC")
+                .icon("font-awesome-solid:exchange-alt")
+                .componentLink("qwc-json-rpc-log.js"));
+        return footer;
     }
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-log.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-log.js
@@ -1,0 +1,172 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import { LogController } from 'log-controller';
+
+export class QwcJsonRpcLog extends LitElement {
+
+    jsonRpc = new JsonRpc(this);
+    logControl = new LogController(this);
+
+    static styles = css`
+        :host {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        .log-container {
+            flex: 1;
+            overflow-y: auto;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.78em;
+            line-height: 1.5;
+        }
+        .entry {
+            padding: 4px 10px;
+            border-bottom: 1px solid var(--lumo-contrast-5pct);
+            display: flex;
+            gap: 8px;
+            align-items: flex-start;
+        }
+        .entry.incoming {
+            background: var(--lumo-primary-color-10pct, #e3f2fd);
+        }
+        .entry.outgoing {
+            background: var(--lumo-contrast-5pct);
+        }
+        .entry.error {
+            background: var(--lumo-error-color-10pct, #ffebee);
+        }
+        .direction {
+            flex: 0 0 16px;
+            text-align: center;
+        }
+        .direction.incoming {
+            color: var(--lumo-primary-color, #1565c0);
+        }
+        .direction.outgoing {
+            color: var(--lumo-success-color, #2e7d32);
+        }
+        .time {
+            flex: 0 0 auto;
+            color: var(--lumo-secondary-text-color);
+            font-size: 0.9em;
+        }
+        .session {
+            flex: 0 0 auto;
+            color: var(--lumo-tertiary-text-color, #999);
+            font-size: 0.9em;
+        }
+        .message {
+            flex: 1;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+        .empty-state {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            color: var(--lumo-secondary-text-color);
+            font-style: italic;
+            font-size: 0.85em;
+        }
+    `;
+
+    static properties = {
+        _messages: { state: true },
+    };
+
+    constructor() {
+        super();
+        this._messages = [];
+        this._observer = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._subscribe();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._unsubscribe();
+    }
+
+    _subscribe() {
+        if (this._observer) return;
+        this._observer = this.jsonRpc.streamLog()
+            .onNext(entry => {
+                const data = entry.result || entry;
+                const updated = [...this._messages, data];
+                this._messages = updated.length > 500 ? updated.slice(-500) : updated;
+                this.updateComplete.then(() => {
+                    const container = this.shadowRoot?.querySelector('.log-container');
+                    if (container) container.scrollTop = container.scrollHeight;
+                });
+            });
+    }
+
+    _unsubscribe() {
+        if (this._observer) {
+            this._observer.cancel();
+            this._observer = null;
+        }
+    }
+
+    _formatTime(timestamp) {
+        try {
+            return new Date(timestamp).toLocaleTimeString();
+        } catch (e) {
+            return timestamp;
+        }
+    }
+
+    _truncateSession(sessionId) {
+        if (!sessionId) return '';
+        return sessionId.substring(0, 8);
+    }
+
+    _isError(msg) {
+        try {
+            const parsed = JSON.parse(msg);
+            return parsed.error !== undefined && parsed.error !== null;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    _formatJson(msg) {
+        try {
+            return JSON.stringify(JSON.parse(msg), null, 2);
+        } catch (e) {
+            return msg;
+        }
+    }
+
+    render() {
+        if (this._messages.length === 0) {
+            return html`<div class="empty-state">Waiting for JSON-RPC messages on /json-rpc ...</div>`;
+        }
+        return html`
+            <div class="log-container">
+                ${this._messages.map(m => {
+                    const isError = this._isError(m.message);
+                    const entryClass = isError ? 'entry error'
+                        : m.direction === 'incoming' ? 'entry incoming' : 'entry outgoing';
+                    return html`
+                        <div class="${entryClass}">
+                            <span class="direction ${m.direction}">
+                                ${m.direction === 'incoming' ? '⬆' : '⬇'}
+                            </span>
+                            <span class="time">${this._formatTime(m.timestamp)}</span>
+                            <span class="session">${this._truncateSession(m.sessionId)}</span>
+                            <span class="message">${this._formatJson(m.message)}</span>
+                        </div>
+                    `;
+                })}
+            </div>
+        `;
+    }
+}
+
+customElements.define('qwc-json-rpc-log', QwcJsonRpcLog);

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
@@ -6,6 +6,8 @@ import { JsonRpc } from 'jsonrpc';
 export class QwcJsonRpcTester extends LitElement {
 
     static _nextRequestId = 0;
+    static _connections = new Map();
+
     jsonRpc = new JsonRpc(this);
 
     static styles = css`
@@ -104,6 +106,8 @@ export class QwcJsonRpcTester extends LitElement {
         this._result = null;
         this._streaming = false;
         this._streamItems = [];
+        this._subscriptionId = null;
+        this._subscriptionPath = null;
     }
 
     connectedCallback() {
@@ -216,7 +220,6 @@ export class QwcJsonRpcTester extends LitElement {
             this._selectedMethod.parameters.split(', ').forEach(p => {
                 const name = p.split(':')[0].trim();
                 let val = this._paramValues[name] || '';
-                // Try to parse as JSON for non-string values
                 try {
                     val = JSON.parse(val);
                 } catch (e) {
@@ -226,25 +229,94 @@ export class QwcJsonRpcTester extends LitElement {
             });
         }
 
-        // Use the Dev UI jsonrpc to call our service's listMethods,
-        // but the actual invocation goes through the extension's own WS.
-        // For the tester, we connect directly via WebSocket.
         this._invokeViaWebSocket(params);
     }
 
-    _invokeViaWebSocket(params) {
+    static _getConnection(path) {
         const loc = window.location;
         const wsProtocol = loc.protocol === 'https:' ? 'wss:' : 'ws:';
-        const methodPath = this._selectedMethod?.path || endpointPath;
-        const wsUrl = `${wsProtocol}//${loc.host}${methodPath}`;
+        const wsUrl = `${wsProtocol}//${loc.host}${path}`;
+
+        let conn = QwcJsonRpcTester._connections.get(path);
+        if (conn && conn.ws.readyState === WebSocket.OPEN) {
+            return Promise.resolve(conn);
+        }
+
+        if (conn && conn.ws.readyState === WebSocket.CONNECTING) {
+            return conn.ready;
+        }
+
+        // Clean up old connection if it exists
+        if (conn) {
+            conn.ws.close();
+        }
 
         const ws = new WebSocket(wsUrl);
-        // Strip params suffix from the key — the server appends param names
-        // from the request's named params to build the lookup key
+        conn = {
+            ws,
+            pending: new Map(),
+            subscriptions: new Map(),
+            ready: null,
+        };
+
+        conn.ready = new Promise((resolve, reject) => {
+            ws.onopen = () => resolve(conn);
+            ws.onerror = () => reject(new Error('WebSocket connection error'));
+        });
+
+        ws.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+
+            // Subscription notification
+            if (data.method === 'subscription' && data.params) {
+                const subId = data.params.subscription;
+                const sub = conn.subscriptions.get(subId);
+                if (sub) {
+                    if (data.params.result !== undefined) {
+                        sub.onItem(data.params.result);
+                    }
+                    if (data.params.complete) {
+                        sub.onComplete();
+                        conn.subscriptions.delete(subId);
+                    }
+                    if (data.params.error) {
+                        sub.onError(data.params.error);
+                        conn.subscriptions.delete(subId);
+                    }
+                }
+                return;
+            }
+
+            // Regular response
+            if (data.id !== undefined) {
+                const handler = conn.pending.get(data.id);
+                if (handler) {
+                    conn.pending.delete(data.id);
+                    handler(data);
+                }
+            }
+        };
+
+        ws.onclose = () => {
+            QwcJsonRpcTester._connections.delete(path);
+            conn.pending.forEach(handler => handler({
+                error: { code: -1, message: 'WebSocket closed' }
+            }));
+            conn.pending.clear();
+            conn.subscriptions.forEach(sub => sub.onError('WebSocket closed'));
+            conn.subscriptions.clear();
+        };
+
+        QwcJsonRpcTester._connections.set(path, conn);
+        return conn.ready;
+    }
+
+    _invokeViaWebSocket(params) {
+        const methodPath = this._selectedMethod?.path || endpointPath;
         const method = this._selectedMethod.key.replace(/\(.*\)$/, '');
         const requestId = ++QwcJsonRpcTester._nextRequestId;
 
-        ws.onopen = () => {
+        QwcJsonRpcTester._getConnection(methodPath).then(conn => {
             const request = {
                 jsonrpc: '2.0',
                 id: requestId,
@@ -253,70 +325,65 @@ export class QwcJsonRpcTester extends LitElement {
             if (Object.keys(params).length > 0) {
                 request.params = params;
             }
-            ws.send(JSON.stringify(request));
-        };
 
-        ws.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            if (data.id === requestId && data.result !== undefined) {
-                // Check if the result is a subscription ID (UUID pattern)
-                if (typeof data.result === 'string' &&
-                    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(data.result)) {
-                    this._streaming = true;
-                    this._subscriptionId = data.result;
-                    this._ws = ws;
-                    this._result = `Subscription started: ${data.result}`;
-                    return; // Keep connection open for streaming
+            conn.pending.set(requestId, (data) => {
+                if (data.result !== undefined) {
+                    if (typeof data.result === 'string' &&
+                        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(data.result)) {
+                        this._streaming = true;
+                        this._subscriptionId = data.result;
+                        this._subscriptionPath = methodPath;
+                        this._result = `Subscription started: ${data.result}`;
+                        conn.subscriptions.set(data.result, {
+                            onItem: (item) => {
+                                this._streamItems = [...this._streamItems, item];
+                            },
+                            onComplete: () => {
+                                this._streaming = false;
+                                this._result = 'Stream completed';
+                                conn.subscriptions.delete(this._subscriptionId);
+                                this._subscriptionId = null;
+                                this._subscriptionPath = null;
+                            },
+                            onError: (err) => {
+                                this._streaming = false;
+                                this._result = `Stream error: ${err}`;
+                                conn.subscriptions.delete(this._subscriptionId);
+                                this._subscriptionId = null;
+                                this._subscriptionPath = null;
+                            },
+                        });
+                        return;
+                    }
+                    this._result = data.result;
+                } else if (data.error) {
+                    this._result = `Error: ${data.error.message} (code: ${data.error.code})`;
                 }
-                this._result = data.result;
-                ws.close();
-            } else if (data.id === requestId && data.error) {
-                this._result = `Error: ${data.error.message} (code: ${data.error.code})`;
-                ws.close();
-            } else if (data.method === 'subscription' && data.params) {
-                // Streaming item
-                if (data.params.subscription === this._subscriptionId) {
-                    if (data.params.result !== undefined) {
-                        this._streamItems = [...this._streamItems, data.params.result];
-                    }
-                    if (data.params.complete) {
-                        this._streaming = false;
-                        this._result = 'Stream completed';
-                        ws.close();
-                    }
-                    if (data.params.error) {
-                        this._streaming = false;
-                        this._result = `Stream error: ${data.params.error}`;
-                        ws.close();
-                    }
-                }
-            }
-        };
+            });
 
-        ws.onerror = () => {
-            this._result = 'WebSocket connection error';
-            ws.close();
-        };
+            conn.ws.send(JSON.stringify(request));
+        }).catch(err => {
+            this._result = `Connection error: ${err.message}`;
+        });
     }
 
     _cancelStream() {
-        if (this._ws && this._subscriptionId) {
-            const request = {
-                jsonrpc: '2.0',
-                id: ++QwcJsonRpcTester._nextRequestId,
-                method: 'unsubscribe',
-                params: [this._subscriptionId],
-            };
-            try {
-                this._ws.send(JSON.stringify(request));
-                this._ws.close();
-            } catch (e) {
-                // ignore if already closed
+        if (this._subscriptionId && this._subscriptionPath) {
+            const conn = QwcJsonRpcTester._connections.get(this._subscriptionPath);
+            if (conn && conn.ws.readyState === WebSocket.OPEN) {
+                const request = {
+                    jsonrpc: '2.0',
+                    id: ++QwcJsonRpcTester._nextRequestId,
+                    method: 'unsubscribe',
+                    params: [this._subscriptionId],
+                };
+                conn.ws.send(JSON.stringify(request));
+                conn.subscriptions.delete(this._subscriptionId);
             }
         }
         this._streaming = false;
         this._subscriptionId = null;
-        this._ws = null;
+        this._subscriptionPath = null;
     }
 }
 

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRecorder.java
@@ -89,4 +89,8 @@ public class JsonRPCRecorder {
     public Handler<RoutingContext> openRpcHandler(String openrpcDocument) {
         return new OpenRPCHandler(openrpcDocument);
     }
+
+    public void enableMessageLog(BeanContainer beanContainer) {
+        beanContainer.beanInstance(JsonRPCRouter.class).enableMessageLog();
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -3,6 +3,7 @@ package io.quarkiverse.jsonrpc.runtime;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.context.SmallRyeThreadContext;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.subscription.Cancellable;
 import io.smallrye.mutiny.unchecked.Unchecked;
 import io.vertx.core.AsyncResult;
@@ -78,6 +80,8 @@ public class JsonRPCRouter {
 
     private final Duration methodTimeout;
 
+    private volatile BroadcastProcessor<io.vertx.core.json.JsonObject> messageLogProcessor;
+
     public JsonRPCRouter(JsonRPCCodec codec, JsonRPCSessions sessions,
             Map<JsonRPCMethodName, JsonRPCMethod> methodsMap,
             Map<String, String> scopeToPath, String defaultPath,
@@ -86,6 +90,41 @@ public class JsonRPCRouter {
         this.sessions = sessions;
         this.methodTimeout = methodTimeout;
         populateJsonRPCMethods(methodsMap, scopeToPath, defaultPath);
+    }
+
+    public void enableMessageLog() {
+        this.messageLogProcessor = BroadcastProcessor.create();
+        this.codec.setMessageLogListener((socket, json) -> {
+            BroadcastProcessor<io.vertx.core.json.JsonObject> p = this.messageLogProcessor;
+            if (p != null) {
+                String sessionId = sessions.getSessionId(socket);
+                p.onNext(new io.vertx.core.json.JsonObject()
+                        .put("direction", "outgoing")
+                        .put("sessionId", sessionId != null ? sessionId : "unknown")
+                        .put("timestamp", Instant.now().toString())
+                        .put("message", json));
+            }
+        });
+    }
+
+    public Multi<io.vertx.core.json.JsonObject> streamMessageLog() {
+        BroadcastProcessor<io.vertx.core.json.JsonObject> p = this.messageLogProcessor;
+        if (p == null) {
+            return Multi.createFrom().empty();
+        }
+        return p;
+    }
+
+    private void logIncoming(ServerWebSocket socket, String rawJson) {
+        BroadcastProcessor<io.vertx.core.json.JsonObject> p = this.messageLogProcessor;
+        if (p != null) {
+            String sessionId = sessions.getSessionId(socket);
+            p.onNext(new io.vertx.core.json.JsonObject()
+                    .put("direction", "incoming")
+                    .put("sessionId", sessionId != null ? sessionId : "unknown")
+                    .put("timestamp", Instant.now().toString())
+                    .put("message", rawJson));
+        }
     }
 
     private static JsonRPCMetricsHandler metrics() {
@@ -261,6 +300,7 @@ public class JsonRPCRouter {
         }
         fireEvent(new JsonRPCConnected(sessionId));
         socket.textMessageHandler((e) -> {
+            logIncoming(socket, e);
             try {
                 JsonNode jsonNode;
                 try {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
@@ -11,6 +11,7 @@ import io.quarkiverse.jsonrpc.runtime.ReflectionInfo;
 import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonArray;
@@ -91,6 +92,10 @@ public class JsonRPCDevUIService {
             }
         }
         return result;
+    }
+
+    public Multi<JsonObject> streamLog() {
+        return router.streamMessageLog();
     }
 
     private String getReturnTypeDescription(ReflectionInfo info) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/model/JsonRPCCodec.java
@@ -3,6 +3,7 @@ package io.quarkiverse.jsonrpc.runtime.model;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.jboss.logging.Logger;
 
@@ -16,10 +17,15 @@ import io.vertx.core.http.ServerWebSocket;
 public class JsonRPCCodec {
     private static final Logger LOG = Logger.getLogger(JsonRPCCodec.class);
     private final ObjectMapper objectMapper;
+    private volatile BiConsumer<ServerWebSocket, String> messageLogListener;
 
     public JsonRPCCodec(ObjectMapper originalObjectMapper) {
         this.objectMapper = originalObjectMapper.copy(); // we should never change settings of the original ObjectMapper as they could have global impact
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    public void setMessageLogListener(BiConsumer<ServerWebSocket, String> listener) {
+        this.messageLogListener = listener;
     }
 
     public JsonNode parseJson(String json) throws JsonProcessingException {
@@ -32,7 +38,9 @@ public class JsonRPCCodec {
 
     public void writeResponse(ServerWebSocket socket, JsonRPCResponse<?> response) {
         try {
-            socket.writeTextMessage(objectMapper.writeValueAsString(response));
+            String json = objectMapper.writeValueAsString(response);
+            socket.writeTextMessage(json);
+            logOutgoing(socket, json);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }
@@ -40,7 +48,9 @@ public class JsonRPCCodec {
 
     public void writeBatchResponse(ServerWebSocket socket, List<JsonRPCResponse<?>> responses) {
         try {
-            socket.writeTextMessage(objectMapper.writeValueAsString(responses));
+            String json = objectMapper.writeValueAsString(responses);
+            socket.writeTextMessage(json);
+            logOutgoing(socket, json);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }
@@ -80,11 +90,20 @@ public class JsonRPCCodec {
             return;
         }
         try {
-            socket.writeTextMessage(objectMapper.writeValueAsString(notification));
+            String json = objectMapper.writeValueAsString(notification);
+            socket.writeTextMessage(json);
+            logOutgoing(socket, json);
         } catch (JsonProcessingException ex) {
             LOG.errorf(ex, "Failed to serialize JSON-RPC notification: method=%s", notification.method);
             throw new RuntimeException(
                     "Failed to serialize JSON-RPC notification for method '" + notification.method + "'", ex);
+        }
+    }
+
+    private void logOutgoing(ServerWebSocket socket, String json) {
+        BiConsumer<ServerWebSocket, String> listener = this.messageLogListener;
+        if (listener != null) {
+            listener.accept(socket, json);
         }
     }
 }


### PR DESCRIPTION
The Dev UI tester was creating a new WebSocket connection for every method invocation and closing it after the response. Connections are now cached per path and reused, matching the behavior of the generated JavaScript client.

A JSON-RPC message log is added to the Dev UI footer, showing all raw incoming and outgoing messages flowing through the extension's WebSocket endpoint. The log captures traffic from all clients via server-side interception in the codec and router, streamed to the UI as a Multi subscription through the existing Dev UI JSON-RPC service. The footer placement keeps the log visible while navigating between extension pages.