### PR TITLE
Add config prefix to extension metadata for Dev UI config filter

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,3 +12,5 @@ metadata:
   categories:
     - "web"
   status: "preview"
+  config:
+    - "quarkus.json-rpc."


### PR DESCRIPTION
The Dev UI Configuration page has an extension filter dropdown that lets
users narrow visible properties to a specific extension. This was not
working for quarkus-json-rpc because the `quarkus.json-rpc.` config
prefix was not declared in `quarkus-extension.yaml` metadata.

Adds `config: ["quarkus.json-rpc."]` to the extension metadata, matching
the pattern used by core extensions like ArC.