### PR TITLE
Add Dev UI hot-reload support to all pages

### DIFF
--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-log.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-log.js
@@ -1,8 +1,8 @@
-import { LitElement, html, css } from 'lit';
+import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
 import { JsonRpc } from 'jsonrpc';
 import { LogController } from 'log-controller';
 
-export class QwcJsonRpcLog extends LitElement {
+export class QwcJsonRpcLog extends QwcHotReloadElement {
 
     jsonRpc = new JsonRpc(this);
     logControl = new LogController(this);
@@ -90,6 +90,12 @@ export class QwcJsonRpcLog extends LitElement {
     disconnectedCallback() {
         super.disconnectedCallback();
         this._unsubscribe();
+    }
+
+    hotReload() {
+        this._unsubscribe();
+        this._messages = [];
+        this._subscribe();
     }
 
     _subscribe() {

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
@@ -84,6 +84,8 @@ export class QwcJsonRpcMethods extends QwcHotReloadElement {
     hotReload() {
         this.jsonRpc.listMethods().then(r => {
             this._methods = r.result || [];
+        }).catch(e => {
+            console.warn('Failed to reload JSON-RPC methods', e);
         });
     }
 

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-methods.js
@@ -1,13 +1,15 @@
-import { LitElement, html, css } from 'lit';
+import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
 import { methods } from 'build-time-data';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import { RouterController } from 'router-controller';
+import { JsonRpc } from 'jsonrpc';
 
-export class QwcJsonRpcMethods extends LitElement {
+export class QwcJsonRpcMethods extends QwcHotReloadElement {
 
     routerController = new RouterController(this);
+    jsonRpc = new JsonRpc(this);
 
     static styles = css`
         :host {
@@ -43,9 +45,18 @@ export class QwcJsonRpcMethods extends LitElement {
         }
     `;
 
+    static properties = {
+        _methods: { state: true },
+    };
+
+    constructor() {
+        super();
+        this._methods = methods;
+    }
+
     render() {
         return html`
-            <vaadin-grid .items=${methods} class="methods-grid" theme="no-border">
+            <vaadin-grid .items=${this._methods} class="methods-grid" theme="no-border">
                 <vaadin-grid-sort-column path="key" header="Key" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="className" header="Class" auto-width resizable></vaadin-grid-sort-column>
                 <vaadin-grid-sort-column path="methodName" header="Method" auto-width resizable></vaadin-grid-sort-column>
@@ -68,6 +79,12 @@ export class QwcJsonRpcMethods extends LitElement {
                 </vaadin-grid-column>
             </vaadin-grid>
         `;
+    }
+
+    hotReload() {
+        this.jsonRpc.listMethods().then(r => {
+            this._methods = r.result || [];
+        });
     }
 
     _testMethod(key) {

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-sessions.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-sessions.js
@@ -1,7 +1,7 @@
-import { LitElement, html, css } from 'lit';
+import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
 import { JsonRpc } from 'jsonrpc';
 
-export class QwcJsonRpcSessions extends LitElement {
+export class QwcJsonRpcSessions extends QwcHotReloadElement {
 
     jsonRpc = new JsonRpc(this);
 
@@ -132,6 +132,10 @@ export class QwcJsonRpcSessions extends LitElement {
                 <div class="empty-state">No active subscriptions</div>
             `}
         `;
+    }
+
+    hotReload() {
+        this._refresh();
     }
 
     _refresh() {

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
@@ -121,7 +121,19 @@ export class QwcJsonRpcTester extends QwcHotReloadElement {
 
     connectedCallback() {
         super.connectedCallback();
-        this._loadMethods();
+        const preselected = sessionStorage.getItem('jsonrpc-test-method');
+        if (preselected) {
+            sessionStorage.removeItem('jsonrpc-test-method');
+        }
+        this._loadMethods(preselected || undefined);
+    }
+
+    willUpdate() {
+        const preselected = sessionStorage.getItem('jsonrpc-test-method');
+        if (preselected) {
+            sessionStorage.removeItem('jsonrpc-test-method');
+            this._loadMethods(preselected);
+        }
     }
 
     _loadMethods(preselectedKey) {
@@ -137,6 +149,8 @@ export class QwcJsonRpcTester extends QwcHotReloadElement {
             if (!this._selectedMethod || !this._methods.find(m => m.key === this._selectedMethod.key)) {
                 this._selectedMethod = this._methods.length > 0 ? this._methods[0] : null;
             }
+        }).catch(e => {
+            console.warn('Failed to load JSON-RPC methods', e);
         });
     }
 
@@ -146,11 +160,6 @@ export class QwcJsonRpcTester extends QwcHotReloadElement {
     }
 
     render() {
-        const preselected = sessionStorage.getItem('jsonrpc-test-method');
-        if (preselected) {
-            sessionStorage.removeItem('jsonrpc-test-method');
-            this._loadMethods(preselected);
-        }
         return html`
             <span class="endpoint-info">Endpoint: <code>${this._selectedMethod?.path || endpointPath}</code></span>
 

--- a/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
+++ b/deployment/src/main/resources/dev-ui/qwc-json-rpc-tester.js
@@ -1,9 +1,9 @@
-import { LitElement, html, css } from 'lit';
+import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
 import { methods } from 'build-time-data';
 import { endpointPath } from 'build-time-data';
 import { JsonRpc } from 'jsonrpc';
 
-export class QwcJsonRpcTester extends LitElement {
+export class QwcJsonRpcTester extends QwcHotReloadElement {
 
     static _nextRequestId = 0;
     static _connections = new Map();
@@ -99,6 +99,7 @@ export class QwcJsonRpcTester extends LitElement {
     `;
 
     static properties = {
+        _methods: { state: true },
         _selectedMethod: { state: true },
         _paramValues: { state: true },
         _result: { state: true },
@@ -108,6 +109,7 @@ export class QwcJsonRpcTester extends LitElement {
 
     constructor() {
         super();
+        this._methods = methods;
         this._selectedMethod = null;
         this._paramValues = {};
         this._result = null;
@@ -119,18 +121,23 @@ export class QwcJsonRpcTester extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        const preselected = sessionStorage.getItem('jsonrpc-test-method');
-        if (preselected) {
-            sessionStorage.removeItem('jsonrpc-test-method');
-            const found = methods.find(m => m.key === preselected);
-            if (found) {
-                this._selectedMethod = found;
-                return;
+        this._loadMethods();
+    }
+
+    _loadMethods(preselectedKey) {
+        this.jsonRpc.listMethods().then(r => {
+            this._methods = r.result || [];
+            if (preselectedKey) {
+                const found = this._methods.find(m => m.key === preselectedKey);
+                if (found) {
+                    this._selectedMethod = found;
+                    return;
+                }
             }
-        }
-        if (methods && methods.length > 0) {
-            this._selectedMethod = methods[0];
-        }
+            if (!this._selectedMethod || !this._methods.find(m => m.key === this._selectedMethod.key)) {
+                this._selectedMethod = this._methods.length > 0 ? this._methods[0] : null;
+            }
+        });
     }
 
     disconnectedCallback() {
@@ -139,13 +146,18 @@ export class QwcJsonRpcTester extends LitElement {
     }
 
     render() {
+        const preselected = sessionStorage.getItem('jsonrpc-test-method');
+        if (preselected) {
+            sessionStorage.removeItem('jsonrpc-test-method');
+            this._loadMethods(preselected);
+        }
         return html`
             <span class="endpoint-info">Endpoint: <code>${this._selectedMethod?.path || endpointPath}</code></span>
 
             <div class="form-row">
                 <label>Method:</label>
                 <select @change=${this._onMethodSelect}>
-                    ${methods.map(m => html`
+                    ${this._methods.map(m => html`
                         <option value=${m.key} ?selected=${this._selectedMethod?.key === m.key}>
                             ${m.key}
                         </option>
@@ -213,9 +225,19 @@ export class QwcJsonRpcTester extends LitElement {
         `;
     }
 
+    hotReload() {
+        this._cancelStream();
+        QwcJsonRpcTester._connections.forEach(conn => conn.ws.close());
+        QwcJsonRpcTester._connections.clear();
+        this._paramValues = {};
+        this._result = null;
+        this._streamItems = [];
+        this._loadMethods();
+    }
+
     _onMethodSelect(e) {
         const key = e.target.value;
-        this._selectedMethod = methods.find(m => m.key === key);
+        this._selectedMethod = this._methods.find(m => m.key === key);
         this._paramValues = {};
         this._result = null;
         this._streamItems = [];

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/JsonRPCRouter.java
@@ -281,6 +281,10 @@ public class JsonRPCRouter {
         return Collections.unmodifiableMap(jsonRpcToJava);
     }
 
+    public Map<String, String> getMethodPaths() {
+        return Collections.unmodifiableMap(methodKeyToAllowedPath);
+    }
+
     public Map<ServerWebSocket, Map<String, Cancellable>> getSocketSubscriptions() {
         return Collections.unmodifiableMap(socketSubscriptions);
     }

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
@@ -43,15 +43,21 @@ public class JsonRPCDevUIService {
             method.put("methodName", info.method.getName());
             method.put("path", methodPaths.getOrDefault(key, ""));
 
+            JsonArray params = new JsonArray();
             if (info.params != null && !info.params.isEmpty()) {
                 StringJoiner sj = new StringJoiner(", ");
                 for (Map.Entry<String, Class> param : info.params.entrySet()) {
                     sj.add(param.getKey() + ": " + param.getValue().getSimpleName());
+                    params.add(new JsonObject()
+                            .put("name", param.getKey())
+                            .put("type", param.getValue().getSimpleName()));
                 }
                 method.put("parameters", sj.toString());
             } else {
                 method.put("parameters", "");
             }
+            method.put("params", params);
+            method.put("returnType", getReturnTypeDescription(info));
             method.put("executionMode", getExecutionMode(info));
             method.put("security", resolveSecurityConstraint(info));
 
@@ -101,6 +107,35 @@ public class JsonRPCDevUIService {
 
     public Multi<JsonObject> streamLog() {
         return router.streamMessageLog();
+    }
+
+    private String getReturnTypeDescription(ReflectionInfo info) {
+        Class<?> returnType = info.method.getReturnType();
+        java.lang.reflect.Type genericReturn = info.method.getGenericReturnType();
+
+        if (info.isReturningMulti()) {
+            return "Multi<" + getGenericArg(genericReturn) + ">";
+        } else if (info.isReturningUni()) {
+            return "Uni<" + getGenericArg(genericReturn) + ">";
+        } else if (info.isReturningCompletionStage()) {
+            return "CompletionStage<" + getGenericArg(genericReturn) + ">";
+        } else if (info.isReturningFlowPublisher()) {
+            return "Flow.Publisher<" + getGenericArg(genericReturn) + ">";
+        }
+        return returnType.getSimpleName();
+    }
+
+    private String getGenericArg(java.lang.reflect.Type type) {
+        if (type instanceof java.lang.reflect.ParameterizedType pt) {
+            java.lang.reflect.Type[] args = pt.getActualTypeArguments();
+            if (args.length > 0) {
+                if (args[0] instanceof Class<?> c) {
+                    return c.getSimpleName();
+                }
+                return args[0].getTypeName();
+            }
+        }
+        return "?";
     }
 
     private String resolveSecurityConstraint(ReflectionInfo info) {

--- a/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
+++ b/runtime/src/main/java/io/quarkiverse/jsonrpc/runtime/devui/JsonRPCDevUIService.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.jsonrpc.runtime.devui;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import jakarta.inject.Inject;
 
@@ -30,25 +33,27 @@ public class JsonRPCDevUIService {
     @DevMCPEnableByDefault
     public JsonArray listMethods() {
         JsonArray methods = new JsonArray();
+        Map<String, String> methodPaths = router.getMethodPaths();
         for (Map.Entry<String, ReflectionInfo> entry : router.getRegisteredMethods().entrySet()) {
             String key = entry.getKey();
             ReflectionInfo info = entry.getValue();
             JsonObject method = new JsonObject();
             method.put("key", key);
-            method.put("className", info.bean.getName());
+            method.put("className", info.bean.getSimpleName());
             method.put("methodName", info.method.getName());
-            method.put("returnType", getReturnTypeDescription(info));
+            method.put("path", methodPaths.getOrDefault(key, ""));
 
-            JsonArray params = new JsonArray();
-            if (info.params != null) {
+            if (info.params != null && !info.params.isEmpty()) {
+                StringJoiner sj = new StringJoiner(", ");
                 for (Map.Entry<String, Class> param : info.params.entrySet()) {
-                    params.add(new JsonObject()
-                            .put("name", param.getKey())
-                            .put("type", param.getValue().getSimpleName()));
+                    sj.add(param.getKey() + ": " + param.getValue().getSimpleName());
                 }
+                method.put("parameters", sj.toString());
+            } else {
+                method.put("parameters", "");
             }
-            method.put("parameters", params);
             method.put("executionMode", getExecutionMode(info));
+            method.put("security", resolveSecurityConstraint(info));
 
             methods.add(method);
         }
@@ -98,33 +103,42 @@ public class JsonRPCDevUIService {
         return router.streamMessageLog();
     }
 
-    private String getReturnTypeDescription(ReflectionInfo info) {
-        Class<?> returnType = info.method.getReturnType();
-        java.lang.reflect.Type genericReturn = info.method.getGenericReturnType();
+    private String resolveSecurityConstraint(ReflectionInfo info) {
+        Method method = info.method;
 
-        if (info.isReturningMulti()) {
-            return "Multi<" + getGenericArg(genericReturn) + ">";
-        } else if (info.isReturningUni()) {
-            return "Uni<" + getGenericArg(genericReturn) + ">";
-        } else if (info.isReturningCompletionStage()) {
-            return "CompletionStage<" + getGenericArg(genericReturn) + ">";
-        } else if (info.isReturningFlowPublisher()) {
-            return "Flow.Publisher<" + getGenericArg(genericReturn) + ">";
+        String label = getSecurityLabel(method.getAnnotations());
+        if (label != null) {
+            return label;
         }
-        return returnType.getSimpleName();
+
+        label = getSecurityLabel(info.bean.getAnnotations());
+        if (label != null) {
+            return label;
+        }
+
+        return "";
     }
 
-    private String getGenericArg(java.lang.reflect.Type type) {
-        if (type instanceof java.lang.reflect.ParameterizedType pt) {
-            java.lang.reflect.Type[] args = pt.getActualTypeArguments();
-            if (args.length > 0) {
-                if (args[0] instanceof Class<?> c) {
-                    return c.getSimpleName();
-                }
-                return args[0].getTypeName();
+    private String getSecurityLabel(Annotation[] annotations) {
+        for (Annotation ann : annotations) {
+            String name = ann.annotationType().getSimpleName();
+            switch (name) {
+                case "RolesAllowed":
+                    try {
+                        String[] roles = (String[]) ann.annotationType().getMethod("value").invoke(ann);
+                        return "@RolesAllowed(" + String.join(", ", roles) + ")";
+                    } catch (Exception e) {
+                        return "@RolesAllowed";
+                    }
+                case "PermitAll":
+                    return "@PermitAll";
+                case "DenyAll":
+                    return "@DenyAll";
+                case "Authenticated":
+                    return "@Authenticated";
             }
         }
-        return "?";
+        return null;
     }
 
     private String getExecutionMode(ReflectionInfo info) {


### PR DESCRIPTION
All four Dev UI web components now extend `QwcHotReloadElement` instead of `LitElement`, so they automatically refresh their data when a Quarkus hot reload occurs.

The Methods and Tester pages previously relied on static `build-time-data` imports which are cached by the browser's ES module system — after a hot reload the cached module still returned stale data. Both pages now fetch fresh method data from the server via `jsonRpc.listMethods()` whenever a hot reload fires or the page is navigated to.

The `listMethods()` service method was updated to return data in the same shape as the build-time data (parameters as formatted string, simple class name, WebSocket path, and security annotations resolved via reflection at runtime).