### PR TITLE
Update documentation for modular transport architecture

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 ** xref:guides-health.adoc[Health Check]
 ** xref:guides-openrpc.adoc[OpenRPC Service Discovery]
 ** xref:guides-javascript-client.adoc[JavaScript Client]
+** xref:guides-domain-socket.adoc[Domain Socket Transport]
 
 .Reference
 ** xref:reference-configuration.adoc[Configuration]

--- a/docs/modules/ROOT/pages/guides-broadcasting.adoc
+++ b/docs/modules/ROOT/pages/guides-broadcasting.adoc
@@ -2,7 +2,7 @@
 
 include::./includes/attributes.adoc[]
 
-The `JsonRPCBroadcaster` service lets you push JSON-RPC notifications from the server to connected WebSocket clients. Inject it into any CDI bean — it does not need to be a `@JsonRPCApi` class.
+The `JsonRPCBroadcaster` service lets you push JSON-RPC notifications from the server to all connected clients regardless of transport. Inject it into any CDI bean - it does not need to be a `@JsonRPCApi` class.
 
 == Broadcast to All Clients
 

--- a/docs/modules/ROOT/pages/guides-concurrency.adoc
+++ b/docs/modules/ROOT/pages/guides-concurrency.adoc
@@ -2,11 +2,11 @@
 
 include::./includes/attributes.adoc[]
 
-When multiple users connect to your JSON-RPC WebSocket endpoint simultaneously, each connection is fully isolated and the backend is designed to handle concurrent load efficiently.
+When multiple clients connect to your JSON-RPC endpoint simultaneously, each connection is fully isolated and the backend is designed to handle concurrent load efficiently. This applies to all transports (WebSocket and domain socket).
 
 == Connection Isolation
 
-Each WebSocket connection is independent. The extension tracks every connection as a separate session with its own unique ID. This means:
+Each connection is independent. The extension tracks every connection as a separate session with its own unique ID. This means:
 
 - **Requests and responses are scoped to a single connection** — a response is always sent back to the socket that made the request, never to another user.
 - **Streaming subscriptions (`Multi<T>`) are per-connection** — each client manages its own subscriptions. When a connection closes, only that connection's subscriptions are cancelled.
@@ -92,7 +92,7 @@ The default thread pool sizes work well for development and moderate loads. For 
 
 | `quarkus.vertx.event-loops-pool-size`
 | 2 × CPU cores
-| Number of event loop threads handling WebSocket I/O and non-blocking methods
+| Number of event loop threads handling I/O and non-blocking methods
 
 | `quarkus.vertx.worker-pool-size`
 | 20

--- a/docs/modules/ROOT/pages/guides-connection-lifecycle.adoc
+++ b/docs/modules/ROOT/pages/guides-connection-lifecycle.adoc
@@ -2,7 +2,7 @@
 
 include::./includes/attributes.adoc[]
 
-The extension fires CDI events when WebSocket clients connect and disconnect. Observe these events to log connections, initialize per-session state, or clean up resources on disconnect.
+The extension fires CDI events when clients connect and disconnect, regardless of transport. Observe these events to log connections, initialize per-session state, or clean up resources on disconnect.
 
 == Observing Connections
 

--- a/docs/modules/ROOT/pages/guides-creating-api.adoc
+++ b/docs/modules/ROOT/pages/guides-creating-api.adoc
@@ -147,7 +147,7 @@ Void methods follow the same execution mode rules as any other method — they a
 
 == Custom Path
 
-By default, all `@JsonRPCApi` classes share the global WebSocket endpoint (see <<websocket-endpoint>> below). You can assign a class to a separate WebSocket path using the `path` attribute:
+By default, all `@JsonRPCApi` classes share the global endpoint (see <<websocket-endpoint>> below). You can assign a class to a separate path using the `path` attribute:
 
 [source,java]
 ----
@@ -160,7 +160,9 @@ public class AdminService {
 }
 ----
 
-This registers an additional WebSocket route at `/admin-rpc`. The methods on `AdminService` are _only_ accessible through the custom path — clients connected to the default global endpoint will receive a "method not found" error if they try to call `AdminService` methods.
+This registers an additional WebSocket route at `/admin-rpc`. The methods on `AdminService` are _only_ accessible through the custom path - clients connected to the default global endpoint will receive a "method not found" error if they try to call `AdminService` methods.
+
+NOTE: Path-based routing applies to the WebSocket transport only. Domain socket connections have access to all methods regardless of `path` attribute.
 
 You can combine `path` with a custom scope:
 
@@ -175,7 +177,7 @@ public class AdminService {
 }
 ----
 
-Now the method is called as `admin#getStatus` via the `/admin-rpc` WebSocket endpoint.
+Now the method is called as `admin#getStatus` via the `/admin-rpc` endpoint.
 
 === Multiple API Groups
 
@@ -205,7 +207,7 @@ This is useful for applying different security policies per path. See xref:guide
 [#websocket-endpoint]
 == WebSocket Endpoint
 
-By default, all JSON-RPC methods are served through a WebSocket endpoint at:
+When using the WebSocket transport, all JSON-RPC methods are served through a WebSocket endpoint at:
 
 ----
 ws://localhost:8080/json-rpc
@@ -214,6 +216,8 @@ ws://localhost:8080/json-rpc
 Classes with a `path` attribute register additional WebSocket routes at their specified paths and are only callable from those paths. Classes without a `path` are served exclusively on the default global endpoint.
 
 See xref:reference-configuration.adoc[Configuration Reference] to change the default path.
+
+For the domain socket transport, see xref:guides-domain-socket.adoc[Domain Socket Transport].
 
 == JSON-RPC 2.0 Protocol
 

--- a/docs/modules/ROOT/pages/guides-domain-socket.adoc
+++ b/docs/modules/ROOT/pages/guides-domain-socket.adoc
@@ -1,0 +1,122 @@
+= Domain Socket Transport
+
+include::./includes/attributes.adoc[]
+
+The domain socket transport serves JSON-RPC 2.0 over Unix domain sockets using JSONL framing (newline-delimited JSON). This is ideal for local inter-process communication where a network connection is unnecessary - for example, agent-to-agent communication, CLI tools, or MCP servers.
+
+== Installation
+
+[source,xml,subs=attributes+]
+----
+<dependency>
+    <groupId>io.quarkiverse.json-rpc</groupId>
+    <artifactId>quarkus-json-rpc-domain-socket</artifactId>
+    <version>{project-version}</version>
+</dependency>
+----
+
+The extension includes Netty native transport for both Linux (epoll) and macOS (kqueue), so domain sockets work out of the box on both platforms.
+
+== Configuration
+
+Enable the transport and configure the socket path in `application.properties`:
+
+[source,properties]
+----
+quarkus.json-rpc.domain-socket.enabled=true
+quarkus.json-rpc.domain-socket.path=/tmp/my-app.sock
+----
+
+[cols="1,1,2"]
+|===
+| Property | Default | Description
+
+| `quarkus.json-rpc.domain-socket.enabled`
+| `false`
+| Enable JSON-RPC over Unix domain socket.
+
+| `quarkus.json-rpc.domain-socket.path`
+| `/tmp/quarkus-json-rpc.sock`
+| Path to the Unix domain socket file.
+|===
+
+The socket file is created when the application starts and cleaned up on shutdown.
+
+== Protocol
+
+Each JSON-RPC message is a single line of JSON terminated by `\n`. This format is commonly known as JSONL or NDJSON (newline-delimited JSON). Responses use the same framing.
+
+Request:
+[source]
+----
+{"jsonrpc":"2.0","id":1,"method":"GreetingService#hello","params":{"name":"World"}}\n
+----
+
+Response:
+[source]
+----
+{"jsonrpc":"2.0","id":1,"result":"Hello World"}\n
+----
+
+Batch requests are supported - send a JSON array as a single line.
+
+== Testing with socat
+
+Once the application is running, use `socat` to send requests from the command line. The subshell with `sleep` keeps the connection open while the server processes the request:
+
+[source,bash]
+----
+(printf '{"jsonrpc":"2.0","id":1,"method":"GreetingService#hello","params":{"name":"World"}}\n'; sleep 3) \
+  | socat - UNIX-CONNECT:/tmp/my-app.sock
+----
+
+== Using with WebSocket
+
+The domain socket transport can be used alongside the WebSocket transport in the same application. Add both dependencies and your `@JsonRPCApi` classes are accessible from both transports simultaneously:
+
+[source,xml,subs=attributes+]
+----
+<dependency>
+    <groupId>io.quarkiverse.json-rpc</groupId>
+    <artifactId>quarkus-json-rpc-websocket</artifactId>
+    <version>{project-version}</version>
+</dependency>
+<dependency>
+    <groupId>io.quarkiverse.json-rpc</groupId>
+    <artifactId>quarkus-json-rpc-domain-socket</artifactId>
+    <version>{project-version}</version>
+</dependency>
+----
+
+== Differences from WebSocket
+
+[cols="1,1,1"]
+|===
+| Feature | WebSocket | Domain Socket
+
+| Framing
+| WebSocket frames
+| Newline-delimited JSON (JSONL)
+
+| Network access
+| Yes (TCP)
+| Local only (Unix socket)
+
+| Browser support
+| Yes
+| No
+
+| Path-based routing
+| `@JsonRPCApi(path = "...")` restricts methods to specific WebSocket paths
+| All methods accessible on the socket regardless of `path` attribute
+
+| Security
+| HTTP auth policies, `Sec-WebSocket-Protocol` token auth
+| Relies on file-system permissions on the socket file
+
+| JavaScript client
+| Generated typed proxy available
+| Not applicable
+|===
+
+All other features work identically across both transports: method discovery, execution modes, parameters, streaming, broadcasting, health checks, metrics, timeouts, and connection lifecycle events.

--- a/docs/modules/ROOT/pages/guides-health.adoc
+++ b/docs/modules/ROOT/pages/guides-health.adoc
@@ -2,7 +2,7 @@
 
 include::./includes/attributes.adoc[]
 
-When the `quarkus-smallrye-health` extension is present, JSON-RPC automatically contributes a readiness health check that reports the WebSocket endpoint status and active connection count. No code changes are needed.
+When the `quarkus-smallrye-health` extension is present, JSON-RPC automatically contributes a readiness health check that reports the active connection count across all transports. No code changes are needed.
 
 == Setup
 
@@ -20,7 +20,7 @@ That's it — the health check is registered automatically.
 
 == Health Check Output
 
-The readiness endpoint (`/q/health/ready`) will include a `JSON-RPC WebSocket` check:
+The readiness endpoint (`/q/health/ready`) will include a `JSON-RPC` check:
 
 [source,json]
 ----
@@ -28,7 +28,7 @@ The readiness endpoint (`/q/health/ready`) will include a `JSON-RPC WebSocket` c
   "status": "UP",
   "checks": [
     {
-      "name": "JSON-RPC WebSocket",
+      "name": "JSON-RPC",
       "status": "UP",
       "data": {
         "activeConnections": 3
@@ -38,7 +38,7 @@ The readiness endpoint (`/q/health/ready`) will include a `JSON-RPC WebSocket` c
 }
 ----
 
-The check always reports `UP` when the WebSocket endpoint is running, and includes the current number of open WebSocket connections as additional data.
+The check always reports `UP` and includes the current number of active connections across all transports (WebSocket and domain socket) as additional data.
 
 == Disabling the Health Check
 

--- a/docs/modules/ROOT/pages/guides-metrics.adoc
+++ b/docs/modules/ROOT/pages/guides-metrics.adoc
@@ -2,7 +2,7 @@
 
 include::./includes/attributes.adoc[]
 
-When the `quarkus-micrometer` extension is present, JSON-RPC automatically records metrics for every method invocation and tracks active WebSocket connections and streaming subscriptions. No configuration or code changes are needed.
+When the `quarkus-micrometer` extension is present, JSON-RPC automatically records metrics for every method invocation and tracks active connections and streaming subscriptions across all transports. No configuration or code changes are needed.
 
 == Setup
 
@@ -30,7 +30,7 @@ That's it — metrics are enabled automatically.
 
 | `jsonrpc.active.connections`
 | Gauge
-| Current number of open WebSocket connections.
+| Current number of active connections across all transports.
 
 | `jsonrpc.subscriptions.active`
 | Gauge

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,11 +1,11 @@
 = Quarkus JSON-RPC
-:description: A Quarkus extension providing JSON-RPC 2.0 protocol support over WebSocket.
+:description: A Quarkus extension providing JSON-RPC 2.0 protocol support over WebSocket and Unix domain sockets.
 
 include::./includes/attributes.adoc[]
 
-*Expose your Java methods as JSON-RPC 2.0 endpoints over WebSocket — with a single annotation.*
+*Expose your Java methods as JSON-RPC 2.0 endpoints — with a single annotation.*
 
-Quarkus JSON-RPC discovers classes annotated with `@JsonRPCApi` at build time and makes their public methods callable via the https://www.jsonrpc.org/specification[JSON-RPC 2.0] protocol over a WebSocket connection. No manual routing, no protocol plumbing.
+Quarkus JSON-RPC discovers classes annotated with `@JsonRPCApi` at build time and makes their public methods callable via the https://www.jsonrpc.org/specification[JSON-RPC 2.0] protocol. Choose your transport: WebSocket for browser and network clients, or JSONL over Unix domain sockets for local IPC. No manual routing, no protocol plumbing.
 
 == In a Glance
 
@@ -45,18 +45,40 @@ Response:
 
 == Installation
 
-Add the extension to your project:
+The extension is split into a transport-agnostic core and pluggable transport modules. Add the transport you need:
+
+=== WebSocket transport
+
+For browser clients, network clients, or any WebSocket-based integration:
 
 [source,xml,subs=attributes+]
 ----
 <dependency>
     <groupId>io.quarkiverse.json-rpc</groupId>
-    <artifactId>quarkus-json-rpc</artifactId>
+    <artifactId>quarkus-json-rpc-websocket</artifactId>
     <version>{project-version}</version>
 </dependency>
 ----
 
+=== Domain socket transport
+
+For local IPC using JSONL (newline-delimited JSON) over Unix domain sockets:
+
+[source,xml,subs=attributes+]
+----
+<dependency>
+    <groupId>io.quarkiverse.json-rpc</groupId>
+    <artifactId>quarkus-json-rpc-domain-socket</artifactId>
+    <version>{project-version}</version>
+</dependency>
+----
+
+Both transports can be used simultaneously in the same application. The `@JsonRPCApi` annotation and all core features work identically regardless of transport.
+
 == Key Features
+
+Pluggable transports::
+WebSocket for browser and network clients, or JSONL over Unix domain sockets for local IPC. Both transports share the same `@JsonRPCApi` annotation and core engine - add a dependency and you're done.
 
 Build-time discovery::
 All `@JsonRPCApi` classes are found at build time via Jandex — no runtime classpath scanning, full ahead-of-time compilation and GraalVM native image support.
@@ -135,6 +157,9 @@ An interactive method browser and tester is available in the Quarkus Dev UI duri
 
 | xref:guides-javascript-client.adoc[JavaScript Client]
 | Generate a typed JavaScript proxy for calling your endpoints from the browser.
+
+| xref:guides-domain-socket.adoc[Domain Socket Transport]
+| Serve JSON-RPC over Unix domain sockets using JSONL framing for local IPC.
 
 | xref:reference-configuration.adoc[Configuration Reference]
 | All available configuration properties.


### PR DESCRIPTION
The module split in #173 introduced domain socket transport and changed the Maven artifact users need to depend on, but the documentation still referenced the old single-module setup.

This updates all affected documentation:

- Installation section now shows both `quarkus-json-rpc-websocket` and `quarkus-json-rpc-domain-socket` as separate dependency options (previously showed `quarkus-json-rpc`)
- New domain socket transport guide covering installation, configuration, JSONL protocol, testing with socat, dual-transport setup, and a comparison table vs WebSocket
- Generalized WebSocket-specific language in guides that apply to all transports: broadcasting, concurrency, connection lifecycle, health check, and metrics
- Health check guide updated to reflect the renamed check (`JSON-RPC` instead of `JSON-RPC WebSocket`)
- Creating an API guide now notes that path-based routing is WebSocket-specific and domain sockets access all methods